### PR TITLE
Add comprehensive unit tests and improve Windows path handling

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -16,24 +16,27 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Run ESLint
-        run: npx eslint main.ts
-      
+        run: npx eslint main.ts 'src/**/*.ts'
+
       - name: Type check
         run: npx tsc --noEmit --skipLibCheck
-      
+
+      - name: Run tests
+        run: npm test
+
       - name: Build
         run: npm run build
-      
+
       - name: Verify build output
         run: |
           test -f main.js || exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build and Release
 on:
   push:
     tags:
-      - '*'
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:
@@ -11,55 +11,24 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-      
+
       - name: Install dependencies
         run: npm ci
-      
+
+      - name: Run tests
+        run: npm test
+
       - name: Build
         run: npm run build
-      
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-      
-      - name: Upload main.js
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./main.js
-          asset_name: main.js
-          asset_content_type: application/javascript
-      
-      - name: Upload manifest.json
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./manifest.json
-          asset_name: manifest.json
-          asset_content_type: application/json
-      
-      - name: Upload styles.css
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./styles.css
-          asset_name: styles.css
-          asset_content_type: text/css
+          files: |
+            main.js
+            manifest.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to FolderBridge will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-02-21
+
+### Added
+- Virtual mount point system: map any absolute filesystem path into the vault at any virtual path
+- `VirtualAdapter` shim wrapping Obsidian's built-in `FileSystemAdapter` via a JavaScript `Proxy`
+- `PathMapper` for bidirectional translation between virtual vault paths and real filesystem paths
+- `SecurityManager` with explicit allowlist enforcement; system directories blocked by default
+- Full Windows support:
+  - Long path prefix (`\\?\`) for paths exceeding 260 characters
+  - UNC network path detection and advisory warnings
+  - Windows reserved filename blocking (`CON`, `NUL`, `COM1`–`COM9`, `LPT1`–`LPT9`)
+  - Case-insensitive NTFS path comparisons
+  - Cross-device move fallback (`EXDEV` → copy-then-delete)
+- Read-only mount flag to prevent accidental writes
+- Mount enable/disable toggle (no removal required)
+- Optional display labels for mounts
+- Dry-run mode: logs all writes to console without executing them
+- Status bar item showing count of active mounts
+- `MountManagerModal` UI for adding and validating mount points
+- Async mount status badges in settings (reachable / read-only / error)
+- `versions.json` for Obsidian's automatic update mechanism
+- Vitest unit test suite (72 tests covering PathMapper, SecurityManager, OSHelpers)
+- GitHub Actions: build check workflow and release workflow using `softprops/action-gh-release`
+
+### Fixed
+- Status bar text was not populated when enabling the status bar item via the settings toggle
+- `stat()` now returns a synthetic folder stat for virtual intermediate directories (e.g. `Projects` when the mount is `Projects/Work`), preventing Obsidian from treating them as non-existent
+- `getVirtualMountsDirectChildren` now correctly surfaces intermediate virtual directories in vault listings so nested mount paths (e.g. `Projects/Work`) are visible when browsing the vault root
+- Binary file copying from vault to a mounted folder now uses `readBinary()` instead of `read()`, preventing UTF-8 corruption of images, PDFs, and other non-text files
+
+[0.1.0]: https://github.com/tescolopio/Obsidian_FolderBridge/releases/tag/0.1.0

--- a/README.md
+++ b/README.md
@@ -1,154 +1,146 @@
-
 # Obsidian FolderBridge
 
-Adds external folders to your Obsidian vault as seamless, native-feeling directories. It creates virtual mount points that map real filesystem paths into the vault, enabling multi-root workspaces without moving or duplicating files.
+Extends Obsidian's single-root vault by letting you mount external folders as seamless, native-feeling directories inside your vault. Files stay in their original locations — no copying, no duplicating, no symlinking required.
+
+---
 
 ## Features
 
-- 🗂️ **Virtual Mount Points**: Map real filesystem paths into your vault without copying files
-- 🔄 **Multi-Root Workspaces**: Work with files from multiple locations simultaneously
-- 🚀 **Seamless Integration**: External folders appear as native directories in Obsidian
-- 💾 **Zero Duplication**: Files stay in their original locations
+- **Virtual Mount Points** — Map any absolute filesystem path into your vault at any virtual path
+- **Multi-Root Workspaces** — Work with files from multiple locations simultaneously
+- **Seamless Integration** — External folders appear and behave as native vault directories in the File Explorer, Quick Switcher, and all Obsidian commands
+- **Zero Duplication** — Files are read and written directly from their real locations
+- **Read-Only Mounts** — Protect external folders from accidental writes
+- **Windows Hardened** — Full support for long paths (>260 chars), UNC network paths, Windows reserved filenames, case-insensitive NTFS comparisons, and cross-device moves
+- **Security Allowlist** — Only explicitly approved real paths can be accessed; system directories are blocked
+- **Dry-Run Mode** — Log all write operations to the console without executing them (safe for testing)
+
+---
+
+## Installation
+
+### From Obsidian Community Plugins (recommended)
+
+1. Open **Settings → Community Plugins** and disable Safe Mode if needed
+2. Click **Browse** and search for **FolderBridge**
+3. Install and enable the plugin
+
+### Manual Installation
+
+1. Download `main.js` and `manifest.json` from the [latest release](https://github.com/tescolopio/Obsidian_FolderBridge/releases/latest)
+2. Copy them to `<your-vault>/.obsidian/plugins/obsidian-folderbridge/`
+3. Enable the plugin in **Settings → Community Plugins**
+
+---
+
+## Quick Start
+
+1. Click the **folder-plus** ribbon icon (or go to **Settings → FolderBridge**)
+2. Click **Add Mount Point**
+3. Fill in:
+   - **Virtual path** — where the folder will appear in your vault, e.g. `Projects/Work`
+   - **Real path** — the absolute path on disk, e.g. `C:\Users\YourName\Documents\Work` (Windows) or `/home/yourname/Documents/Work` (Linux/Mac)
+4. Click **Validate & Add**
+
+The folder now appears in Obsidian's file explorer at the virtual path you chose.
+
+---
+
+## Settings
+
+| Setting | Description |
+|---------|-------------|
+| **Dry-run mode** | Log all writes to console without executing them. Safe for testing. |
+| **Show status bar item** | Display active mount count in Obsidian's status bar. |
+| **Mount list** | Enable, disable, or remove individual mounts. Each mount shows a live reachability badge. |
+
+---
+
+## Windows Notes
+
+- **Long paths**: Paths over 260 characters are handled automatically with the `\\?\` prefix. For best results, also enable **Long Path Support** in Windows Settings → System → For Developers.
+- **Symlinks**: Creating symlinks on Windows requires either Developer Mode or administrator rights. FolderBridge itself does not create symlinks, but the underlying filesystem may encounter related permission errors.
+- **UNC network paths** (`\\server\share\...`): Supported, but file-change watching may not work on some servers and the path may be unavailable offline.
+- **Reserved names**: Files and folders named `CON`, `NUL`, `COM1`–`COM9`, `LPT1`–`LPT9` (Windows reserved device names) are blocked from creation via FolderBridge to prevent cryptic OS errors.
+
+---
+
+## Architecture
+
+FolderBridge installs a lightweight **virtual filesystem adapter shim** that intercepts every I/O call Obsidian makes to its vault:
+
+```
+Obsidian → vault.adapter (Proxy) → VirtualAdapter
+                                        ├── path inside a mount? → Node.js fs APIs (real path)
+                                        └── path outside mounts? → original FileSystemAdapter
+```
+
+A JavaScript `Proxy` forwards all undocumented Obsidian-internal methods transparently to the original adapter, so no Obsidian functionality is broken.
+
+---
 
 ## Development Setup
 
 ### Prerequisites
 
-- Node.js (LTS version 20.x or higher)
-- npm or pnpm package manager
-- Obsidian (with Developer Mode enabled)
+- Node.js 20.x (LTS)
+- npm
 
 ### Installation
 
-1. Clone this repository:
-   ```bash
-   git clone https://github.com/tescolopio/Obsidian_FolderBridge.git
-   cd Obsidian_FolderBridge
-   ```
-
-2. Install dependencies:
-   ```bash
-   npm install
-   ```
-
-3. Build the plugin:
-   ```bash
-   npm run build
-   ```
-
-### Development Workflow
-
-1. **Enable Developer Mode** in Obsidian:
-   - Open Obsidian Settings → Community Plugins
-   - Enable "Developer Mode"
-
-2. **Link the plugin folder** to your vault:
-   ```bash
-   # Create a symbolic link from your vault's plugins directory to this project
-   # Replace YOUR_VAULT_PATH with your actual vault path
-   ln -s "$(pwd)" "YOUR_VAULT_PATH/.obsidian/plugins/obsidian-folderbridge"
-   ```
-
-3. **Start development build** with hot-reload:
-   ```bash
-   npm run dev
-   ```
-
-   This will:
-   - Watch for file changes
-   - Automatically rebuild on save
-   - Enable hot-reload in Obsidian (requires Hot Reload plugin)
-
-4. **Reload the plugin** in Obsidian:
-   - Open Command Palette (Ctrl/Cmd + P)
-   - Run "Reload app without saving"
-   - Or use the Hot Reload plugin for automatic reloading
-
-### Build Scripts
-
-- `npm run dev` - Start development build with watch mode and hot-reload
-- `npm run build` - Create production build with type checking
-- `npm run version` - Bump version in manifest.json and versions.json
-
-### Project Structure
-
-```
-.
-├── main.ts              # Main plugin entry point
-├── manifest.json        # Plugin metadata
-├── package.json         # Node.js dependencies and scripts
-├── tsconfig.json        # TypeScript configuration
-├── esbuild.config.mjs   # Build configuration
-├── version-bump.mjs     # Version management script
-└── .hotreload           # Hot-reload marker file
+```bash
+git clone https://github.com/tescolopio/Obsidian_FolderBridge.git
+cd Obsidian_FolderBridge
+npm install
 ```
 
-### TypeScript Configuration
+### Linking to your vault
 
-The project uses TypeScript with strict type checking enabled. Configuration includes:
-- ES6+ target compilation
-- Source maps for debugging
-- Strict null checks
-- Import helpers from tslib
+```bash
+# Windows (PowerShell, run as administrator or with Developer Mode enabled)
+New-Item -ItemType Junction -Path "$env:APPDATA\obsidian\<YourVault>\.obsidian\plugins\obsidian-folderbridge" -Target (Get-Location)
 
-## Virtual Filesystem Architecture
+# Linux / macOS
+ln -s "$(pwd)" "/path/to/vault/.obsidian/plugins/obsidian-folderbridge"
+```
 
-This plugin provides a foundation for implementing a virtual filesystem adapter that:
-- Intercepts file system operations in Obsidian
-- Routes requests to the appropriate real filesystem path
-- Maintains a mapping between virtual paths and real paths
-- Ensures seamless integration with Obsidian's internal file handling
+### Build scripts
+
+```bash
+npm run dev      # Watch mode with hot-reload
+npm run build    # Production build (type-checks first)
+npm test         # Run unit tests
+npm run version  # Bump version in manifest.json and versions.json
+```
+
+### Project structure
+
+```
+├── main.ts                    # Plugin entry point and settings UI
+├── src/
+│   ├── types.ts               # Shared TypeScript interfaces
+│   ├── PathMapper.ts          # Virtual ↔ real path translation
+│   ├── VirtualAdapter.ts      # Virtual filesystem adapter (core)
+│   ├── SecurityManager.ts     # Allowlist enforcement and validation
+│   ├── OSHelpers.ts           # Platform detection and Windows helpers
+│   └── ui/
+│       └── MountManagerModal.ts  # Add-mount dialog
+├── tests/                     # Vitest unit tests
+├── manifest.json              # Plugin metadata
+├── versions.json              # Version → minAppVersion map
+└── esbuild.config.mjs         # Build configuration
+```
+
+---
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions are welcome! Please open an issue or pull request.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+---
 
 ## License
 
-MIT License - see LICENSE file for details
-=======
-# Obsidian Folder Bridge
-
-Obsidian Folder Bridge extends Obsidian’s single‑root vault model by allowing users to mount external folders as if they were native vault directories. It introduces a virtual filesystem layer that maps real paths on disk into the vault, enabling multi‑root workspaces without moving or duplicating files.
-
-This plugin is designed for users who maintain large archives, multi‑device setups, or structured file systems outside their vault but want seamless access to those resources inside Obsidian.
-
----
-
-Features (Planned)
-
-- Create mount points inside your vault that map to external folders  
-- Browse, read, and edit files stored outside the vault  
-- Treat external folders as native vault directories  
-- Support for multiple filesystem roots  
-- Configurable path mappings with a simple UI  
-- Safe permission prompts and allowlists  
-- Plugin‑level virtual filesystem adapter  
-- Future adapters (network shares, cloud storage, etc.)
-
----
-
-How It Works
-
-Obsidian_FolderBridge introduces a lightweight virtual filesystem layer that intercepts Obsidian’s file operations and routes them to the correct underlying path. This allows external directories to appear in the File Explorer and behave like part of the vault, without modifying the user’s actual folder structure.
-
----
-
-Development Setup
-
-To begin developing Obsidian_FolderBridge:
-
-1. Install Node.js (LTS) and either pnpm or npm.  
-2. Clone the Obsidian sample plugin template or this repository.  
-3. Install dependencies and enable Developer Mode in Obsidian.  
-4. Link the plugin folder into your vault’s .obsidian/plugins/ directory.  
-5. Use the provided build scripts for hot‑reload and TypeScript compilation.
-
-This environment provides a clean foundation for implementing the virtual filesystem adapter and UI components.
-
----
-
-Project Status
-
-This project is in early development. The initial goal is to implement a minimal virtual adapter capable of reading and listing external directories, followed by write operations, UI integration, and mount configuration.
->>>>>>> main
+MIT — see [LICENSE](LICENSE) for details.

--- a/main.ts
+++ b/main.ts
@@ -26,7 +26,7 @@ export default class FolderBridgePlugin extends Plugin {
 
 	// Preserve original adapter so we can restore it on unload
 	private originalAdapter: unknown = null;
-	private statusBarItem: HTMLElement | null = null;
+	statusBarItem: HTMLElement | null = null;
 
 	async onload() {
 		await this.loadSettings();
@@ -222,16 +222,7 @@ class FolderBridgeSettingTab extends PluginSettingTab {
 				.onChange(async val => {
 					this.plugin.settings.dryRun = val;
 					await this.plugin.saveSettings();
-
-					// Propagate dry-run changes to the live adapter, if present.
-					const adapter: any = (this.plugin as any).virtualAdapter;
-					if (adapter) {
-						if (typeof adapter.setDryRun === 'function') {
-							adapter.setDryRun(val);
-						} else if ('dryRun' in adapter) {
-							adapter.dryRun = val;
-						}
-					}
+					this.plugin.virtualAdapter?.setDryRun(val);
 				}));
 
 		new Setting(containerEl)
@@ -248,9 +239,7 @@ class FolderBridgeSettingTab extends PluginSettingTab {
 						// Show status bar item if it doesn't exist yet
 						if (!this.plugin.statusBarItem) {
 							this.plugin.statusBarItem = this.plugin.addStatusBarItem();
-							// If there is existing logic to update the text/content of the
-							// status bar item, it should be invoked here. For example:
-							// this.plugin.updateStatusBar();
+							this.plugin.updateStatusBar();
 						}
 					} else {
 						// Hide status bar item if it exists

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
 				"eslint": "^8.56.0",
 				"obsidian": "^1.12.0",
 				"tslib": "2.6.2",
-				"typescript": "5.3.3"
+				"typescript": "5.3.3",
+				"vitest": "^4.0.18"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -309,6 +310,23 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@esbuild/netbsd-x64": {
 			"version": "0.19.12",
 			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
@@ -326,6 +344,23 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@esbuild/openbsd-x64": {
 			"version": "0.19.12",
 			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
@@ -341,6 +376,23 @@
 			],
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+			"integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
@@ -560,6 +612,13 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -598,6 +657,374 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.58.0.tgz",
+			"integrity": "sha512-mr0tmS/4FoVk1cnaeN244A/wjvGDNItZKR8hRhnmCzygyRXYtKF5jVDSIILR1U97CTzAYmbgIj/Dukg62ggG5w==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.58.0.tgz",
+			"integrity": "sha512-+s++dbp+/RTte62mQD9wLSbiMTV+xr/PeRJEc/sFZFSBRlHPNPVaf5FXlzAL77Mr8FtSfQqCN+I598M8U41ccQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.58.0.tgz",
+			"integrity": "sha512-MFWBwTcYs0jZbINQBXHfSrpSQJq3IUOakcKPzfeSznONop14Pxuqa0Kg19GD0rNBMPQI2tFtu3UzapZpH0Uc1Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.58.0.tgz",
+			"integrity": "sha512-yiKJY7pj9c9JwzuKYLFaDZw5gma3fI9bkPEIyofvVfsPqjCWPglSHdpdwXpKGvDeYDms3Qal8qGMEHZ1M/4Udg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-arm64": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.58.0.tgz",
+			"integrity": "sha512-x97kCoBh5MOevpn/CNK9W1x8BEzO238541BGWBc315uOlN0AD/ifZ1msg+ZQB05Ux+VF6EcYqpiagfLJ8U3LvQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-x64": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.58.0.tgz",
+			"integrity": "sha512-Aa8jPoZ6IQAG2eIrcXPpjRcMjROMFxCt1UYPZZtCxRV68WkuSigYtQ/7Zwrcr2IvtNJo7T2JfDXyMLxq5L4Jlg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.58.0.tgz",
+			"integrity": "sha512-Ob8YgT5kD/lSIYW2Rcngs5kNB/44Q2RzBSPz9brf2WEtcGR7/f/E9HeHn1wYaAwKBni+bdXEwgHvUd0x12lQSA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.58.0.tgz",
+			"integrity": "sha512-K+RI5oP1ceqoadvNt1FecL17Qtw/n9BgRSzxif3rTL2QlIu88ccvY+Y9nnHe/cmT5zbH9+bpiJuG1mGHRVwF4Q==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.58.0.tgz",
+			"integrity": "sha512-T+17JAsCKUjmbopcKepJjHWHXSjeW7O5PL7lEFaeQmiVyw4kkc5/lyYKzrv6ElWRX/MrEWfPiJWqbTvfIvjM1Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.58.0.tgz",
+			"integrity": "sha512-cCePktb9+6R9itIJdeCFF9txPU7pQeEHB5AbHu/MKsfH/k70ZtOeq1k4YAtBv9Z7mmKI5/wOLYjQ+B9QdxR6LA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-gnu": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.58.0.tgz",
+			"integrity": "sha512-iekUaLkfliAsDl4/xSdoCJ1gnnIXvoNz85C8U8+ZxknM5pBStfZjeXgB8lXobDQvvPRCN8FPmmuTtH+z95HTmg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-musl": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.58.0.tgz",
+			"integrity": "sha512-68ofRgJNl/jYJbxFjCKE7IwhbfxOl1muPN4KbIqAIe32lm22KmU7E8OPvyy68HTNkI2iV/c8y2kSPSm2mW/Q9Q==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.58.0.tgz",
+			"integrity": "sha512-dpz8vT0i+JqUKuSNPCP5SYyIV2Lh0sNL1+FhM7eLC457d5B9/BC3kDPp5BBftMmTNsBarcPcoz5UGSsnCiw4XQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-musl": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.58.0.tgz",
+			"integrity": "sha512-4gdkkf9UJ7tafnweBCR/mk4jf3Jfl0cKX9Np80t5i78kjIH0ZdezUv/JDI2VtruE5lunfACqftJ8dIMGN4oHew==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.58.0.tgz",
+			"integrity": "sha512-YFS4vPnOkDTD/JriUeeZurFYoJhPf9GQQEF/v4lltp3mVcBmnsAdjEWhr2cjUCZzZNzxCG0HZOvJU44UGHSdzw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-musl": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.58.0.tgz",
+			"integrity": "sha512-x2xgZlFne+QVNKV8b4wwaCS8pwq3y14zedZ5DqLzjdRITvreBk//4Knbcvm7+lWmms9V9qFp60MtUd0/t/PXPw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.58.0.tgz",
+			"integrity": "sha512-jIhrujyn4UnWF8S+DHSkAkDEO3hLX0cjzxJZPLF80xFyzyUIYgSMRcYQ3+uqEoyDD2beGq7Dj7edi8OnJcS/hg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.58.0.tgz",
+			"integrity": "sha512-+410Srdoh78MKSJxTQ+hZ/Mx+ajd6RjjPwBPNd0R3J9FtL6ZA0GqiiyNjCO9In0IzZkCNrpGymSfn+kgyPQocg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.58.0.tgz",
+			"integrity": "sha512-ZjMyby5SICi227y1MTR3VYBpFTdZs823Rs/hpakufleBoufoOIB6jtm9FEoxn/cgO7l6PM2rCEl5Kre5vX0QrQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-openbsd-x64": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.58.0.tgz",
+			"integrity": "sha512-ds4iwfYkSQ0k1nb8LTcyXw//ToHOnNTJtceySpL3fa7tc/AsE+UpUFphW126A6fKBGJD5dhRvg8zw1rvoGFxmw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.58.0.tgz",
+			"integrity": "sha512-fd/zpJniln4ICdPkjWFhZYeY/bpnaN9pGa6ko+5WD38I0tTqk9lXMgXZg09MNdhpARngmxiCg0B0XUamNw/5BQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.58.0.tgz",
+			"integrity": "sha512-YpG8dUOip7DCz3nr/JUfPbIUo+2d/dy++5bFzgi4ugOGBIox+qMbbqt/JoORwvI/C9Kn2tz6+Bieoqd5+B1CjA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.58.0.tgz",
+			"integrity": "sha512-b9DI8jpFQVh4hIXFr0/+N/TzLdpBIoPzjt0Rt4xJbW3mzguV3mduR9cNgiuFcuL/TeORejJhCWiAXe3E/6PxWA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-gnu": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.58.0.tgz",
+			"integrity": "sha512-CSrVpmoRJFN06LL9xhkitkwUcTZtIotYAF5p6XOR2zW0Zz5mzb3IPpcoPhB02frzMHFNo1reQ9xSF5fFm3hUsQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.58.0.tgz",
+			"integrity": "sha512-QFsBgQNTnh5K0t/sBsjJLq24YVqEIVkGpfN2VHsnN90soZyhaiA9UUHufcctVNL4ypJY0wrwad0wslx2KJQ1/w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
 		"node_modules/@types/codemirror": {
 			"version": "5.60.8",
 			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
@@ -607,6 +1034,13 @@
 			"dependencies": {
 				"@types/tern": "*"
 			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
@@ -854,6 +1288,117 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/@vitest/expect": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+			"integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.0.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.0.18",
+				"@vitest/utils": "4.0.18",
+				"chai": "^6.2.1",
+				"tinyrainbow": "^3.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+			"integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.0.18",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0-0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+			"integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+			"integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.0.18",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+			"integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.0.18",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+			"integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+			"integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.0.18",
+				"tinyrainbow": "^3.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -937,6 +1482,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -988,6 +1543,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/chalk": {
@@ -1099,6 +1664,13 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/esbuild": {
 			"version": "0.19.12",
@@ -1317,6 +1889,16 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1325,6 +1907,16 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -1386,6 +1978,24 @@
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/file-entry-cache": {
@@ -1459,6 +2069,21 @@
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
 		},
 		"node_modules/glob": {
 			"version": "7.2.3",
@@ -1760,6 +2385,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1817,6 +2452,25 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/nanoid": {
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -1838,6 +2492,17 @@
 				"@codemirror/state": "6.5.0",
 				"@codemirror/view": "6.38.6"
 			}
+		},
+		"node_modules/obug": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT"
 		},
 		"node_modules/once": {
 			"version": "1.4.0",
@@ -1952,6 +2617,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1963,6 +2642,35 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.6",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.11",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
 			}
 		},
 		"node_modules/prelude-ls": {
@@ -2044,6 +2752,51 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/rollup": {
+			"version": "4.58.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.58.0.tgz",
+			"integrity": "sha512-wbT0mBmWbIvvq8NeEYWWvevvxnOyhKChir47S66WCxw1SXqhw7ssIYejnQEVt7XYQpsj2y8F9PM+Cr3SNEa0gw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "1.0.8"
+			},
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=18.0.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@rollup/rollup-android-arm-eabi": "4.58.0",
+				"@rollup/rollup-android-arm64": "4.58.0",
+				"@rollup/rollup-darwin-arm64": "4.58.0",
+				"@rollup/rollup-darwin-x64": "4.58.0",
+				"@rollup/rollup-freebsd-arm64": "4.58.0",
+				"@rollup/rollup-freebsd-x64": "4.58.0",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.58.0",
+				"@rollup/rollup-linux-arm-musleabihf": "4.58.0",
+				"@rollup/rollup-linux-arm64-gnu": "4.58.0",
+				"@rollup/rollup-linux-arm64-musl": "4.58.0",
+				"@rollup/rollup-linux-loong64-gnu": "4.58.0",
+				"@rollup/rollup-linux-loong64-musl": "4.58.0",
+				"@rollup/rollup-linux-ppc64-gnu": "4.58.0",
+				"@rollup/rollup-linux-ppc64-musl": "4.58.0",
+				"@rollup/rollup-linux-riscv64-gnu": "4.58.0",
+				"@rollup/rollup-linux-riscv64-musl": "4.58.0",
+				"@rollup/rollup-linux-s390x-gnu": "4.58.0",
+				"@rollup/rollup-linux-x64-gnu": "4.58.0",
+				"@rollup/rollup-linux-x64-musl": "4.58.0",
+				"@rollup/rollup-openbsd-x64": "4.58.0",
+				"@rollup/rollup-openharmony-arm64": "4.58.0",
+				"@rollup/rollup-win32-arm64-msvc": "4.58.0",
+				"@rollup/rollup-win32-ia32-msvc": "4.58.0",
+				"@rollup/rollup-win32-x64-gnu": "4.58.0",
+				"@rollup/rollup-win32-x64-msvc": "4.58.0",
+				"fsevents": "~2.3.2"
+			}
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2104,6 +2857,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -2113,6 +2873,30 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
@@ -2159,6 +2943,63 @@
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+			"integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+			"integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -2250,6 +3091,618 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"node_modules/vite": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "^0.27.0",
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.6",
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.15"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"lightningcss": "^1.21.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+			"integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/android-arm": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+			"integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/android-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+			"integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/android-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+			"integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+			"integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/darwin-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+			"integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+			"integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-arm": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+			"integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+			"integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-ia32": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+			"integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-loong64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+			"integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+			"integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+			"integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+			"integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-s390x": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+			"integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+			"integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+			"integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+			"integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/sunos-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+			"integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/win32-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+			"integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/win32-ia32": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+			"integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/win32-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+			"integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+			"integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.27.3",
+				"@esbuild/android-arm": "0.27.3",
+				"@esbuild/android-arm64": "0.27.3",
+				"@esbuild/android-x64": "0.27.3",
+				"@esbuild/darwin-arm64": "0.27.3",
+				"@esbuild/darwin-x64": "0.27.3",
+				"@esbuild/freebsd-arm64": "0.27.3",
+				"@esbuild/freebsd-x64": "0.27.3",
+				"@esbuild/linux-arm": "0.27.3",
+				"@esbuild/linux-arm64": "0.27.3",
+				"@esbuild/linux-ia32": "0.27.3",
+				"@esbuild/linux-loong64": "0.27.3",
+				"@esbuild/linux-mips64el": "0.27.3",
+				"@esbuild/linux-ppc64": "0.27.3",
+				"@esbuild/linux-riscv64": "0.27.3",
+				"@esbuild/linux-s390x": "0.27.3",
+				"@esbuild/linux-x64": "0.27.3",
+				"@esbuild/netbsd-arm64": "0.27.3",
+				"@esbuild/netbsd-x64": "0.27.3",
+				"@esbuild/openbsd-arm64": "0.27.3",
+				"@esbuild/openbsd-x64": "0.27.3",
+				"@esbuild/openharmony-arm64": "0.27.3",
+				"@esbuild/sunos-x64": "0.27.3",
+				"@esbuild/win32-arm64": "0.27.3",
+				"@esbuild/win32-ia32": "0.27.3",
+				"@esbuild/win32-x64": "0.27.3"
+			}
+		},
+		"node_modules/vite/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/vitest": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+			"integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.0.18",
+				"@vitest/mocker": "4.0.18",
+				"@vitest/pretty-format": "4.0.18",
+				"@vitest/runner": "4.0.18",
+				"@vitest/snapshot": "4.0.18",
+				"@vitest/spy": "4.0.18",
+				"@vitest/utils": "4.0.18",
+				"es-module-lexer": "^1.7.0",
+				"expect-type": "^1.2.2",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^3.10.0",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.0.3",
+				"vite": "^6.0.0 || ^7.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.0.18",
+				"@vitest/browser-preview": "4.0.18",
+				"@vitest/browser-webdriverio": "4.0.18",
+				"@vitest/ui": "4.0.18",
+				"happy-dom": "*",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2264,6 +3717,23 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc --noEmit --skipLibCheck && node esbuild.config.mjs production",
+		"test": "vitest run",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},
 	"keywords": [
@@ -25,6 +26,7 @@
 		"eslint": "^8.56.0",
 		"obsidian": "^1.12.0",
 		"tslib": "2.6.2",
-		"typescript": "5.3.3"
+		"typescript": "5.3.3",
+		"vitest": "^4.0.18"
 	}
 }

--- a/src/PathMapper.ts
+++ b/src/PathMapper.ts
@@ -90,13 +90,22 @@ export class PathMapper {
 		for (const m of this.mounts) {
 			const mv = normalizePath(m.virtualPath);
 			if (parent === '') {
-				// Root: include mounts with no '/' in their path
-				if (!mv.includes('/')) result.push(mv);
+				// Root: return the first path component of each mount so that
+				// intermediate virtual folders (e.g. "Projects" for a mount at
+				// "Projects/Work") also appear in the vault root listing.
+				const firstSlash = mv.indexOf('/');
+				const directChild = firstSlash === -1 ? mv : mv.slice(0, firstSlash);
+				if (!result.includes(directChild)) result.push(directChild);
 			} else {
-				// Non-root: include mounts whose virtualPath is "parent/childName"
+				// Non-root: include the first direct child under this parent,
+				// whether it is the mount itself or an intermediate virtual folder.
 				if (mv.startsWith(parent + '/')) {
 					const remainder = mv.slice(parent.length + 1);
-					if (!remainder.includes('/')) result.push(mv);
+					const nextSlash = remainder.indexOf('/');
+					const directChild = nextSlash === -1
+						? mv
+						: parent + '/' + remainder.slice(0, nextSlash);
+					if (!result.includes(directChild)) result.push(directChild);
 				}
 			}
 		}

--- a/src/VirtualAdapter.ts
+++ b/src/VirtualAdapter.ts
@@ -41,6 +41,9 @@ export class VirtualAdapter {
 		this.dryRun = dryRun;
 	}
 
+	/** Update dry-run mode without reloading the plugin. */
+	setDryRun(val: boolean): void { this.dryRun = val; }
+
 	// ------------------------------------------------------------------
 	// Delegation helper
 	// ------------------------------------------------------------------
@@ -142,6 +145,17 @@ export class VirtualAdapter {
 				return null;
 			}
 		}
+
+		// Virtual intermediate directory: a path that doesn't exist on disk but
+		// is a parent of a mount (e.g. "Projects" when the mount is "Projects/Work").
+		// Obsidian calls stat() on paths it knows exist (from exists()), so we must
+		// return a synthetic folder stat rather than null.
+		if (this.pathMapper.hasMountsUnder(normalizedPath)) {
+			const real = await this.orig().stat(normalizedPath);
+			if (real) return real;
+			return { type: 'folder', ctime: 0, mtime: Date.now(), size: 0 };
+		}
+
 		return this.orig().stat(normalizedPath);
 	}
 
@@ -458,7 +472,7 @@ export class VirtualAdapter {
 			// Read from source
 			const content: Buffer = srcMount
 				? await fs.promises.readFile(this.toReal(normalizedPath, srcMount))
-				: Buffer.from(await this.orig().read(normalizedPath) as string, 'utf8');
+				: Buffer.from(await this.orig().readBinary(normalizedPath) as ArrayBuffer);
 
 			// Write to destination
 			if (dstMount) {
@@ -468,7 +482,7 @@ export class VirtualAdapter {
 				await fs.promises.mkdir(path.dirname(dstReal), { recursive: true });
 				await fs.promises.writeFile(dstReal, content);
 			} else {
-				await this.orig().write(newNormalizedPath, content.toString('utf8'));
+				await this.orig().writeBinary(newNormalizedPath, content.buffer.slice(content.byteOffset, content.byteOffset + content.byteLength) as ArrayBuffer);
 			}
 		} catch (e) {
 			// Re-throw FolderBridge errors unchanged; translate raw fs errors

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,6 @@ export interface FolderBridgeSettings {
 	allowlist: string[];    // Approved real paths (must match before any I/O)
 	dryRun: boolean;        // Log writes without executing them
 	showStatusBar: boolean;
-	logOperations: boolean;
 }
 
 export const DEFAULT_SETTINGS: FolderBridgeSettings = {
@@ -24,7 +23,6 @@ export const DEFAULT_SETTINGS: FolderBridgeSettings = {
 	allowlist: [],
 	dryRun: false,
 	showStatusBar: true,
-	logOperations: false,
 };
 
 export interface MountStatus {

--- a/tests/OSHelpers.test.ts
+++ b/tests/OSHelpers.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+	normalizeRealPath,
+	realPathToResourceUrl,
+	normalizeForComparison,
+	isUNCPath,
+	ensureLongPathPrefix,
+	isReservedWindowsFilename,
+	translateFsError,
+} from '../src/OSHelpers';
+
+// Helper: temporarily override process.platform for Windows-specific tests
+function withPlatform(platform: NodeJS.Platform, fn: () => void): void {
+	const orig = process.platform;
+	Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+	try { fn(); } finally {
+		Object.defineProperty(process, 'platform', { value: orig, configurable: true });
+	}
+}
+
+describe('OSHelpers', () => {
+
+	describe('normalizeRealPath', () => {
+		it('normalizes a POSIX path', () => {
+			expect(normalizeRealPath('/foo//bar/../baz')).toBe('/foo/baz');
+		});
+	});
+
+	describe('realPathToResourceUrl', () => {
+		it('converts a POSIX path to an app:// URL', () => {
+			expect(realPathToResourceUrl('/home/user/image.png')).toBe('app://local/home/user/image.png');
+		});
+
+		it('handles platform paths using path.sep as the separator', () => {
+			// On Linux, path.sep is '/' so POSIX paths work correctly.
+			// On Windows this function converts backslashes to forward slashes.
+			const url = realPathToResourceUrl('/home/user/images/photo.jpg');
+			expect(url).toBe('app://local/home/user/images/photo.jpg');
+		});
+
+		it('ensures a leading slash after the protocol for absolute paths', () => {
+			const url = realPathToResourceUrl('/already/absolute');
+			expect(url.startsWith('app://local/')).toBe(true);
+		});
+	});
+
+	describe('normalizeForComparison', () => {
+		it('preserves case on Linux', () => {
+			withPlatform('linux', () => {
+				expect(normalizeForComparison('/Foo/Bar')).toBe('/Foo/Bar');
+			});
+		});
+
+		it('lowercases paths on Windows', () => {
+			withPlatform('win32', () => {
+				const result = normalizeForComparison('C:\\Users\\NAME');
+				expect(result).toBe(result.toLowerCase());
+			});
+		});
+	});
+
+	describe('isUNCPath', () => {
+		it('detects a UNC path', () => {
+			expect(isUNCPath('\\\\server\\share')).toBe(true);
+		});
+
+		it('returns false for a normal Windows path', () => {
+			expect(isUNCPath('C:\\Users')).toBe(false);
+		});
+
+		it('returns false for a POSIX path', () => {
+			expect(isUNCPath('/home/user')).toBe(false);
+		});
+	});
+
+	describe('ensureLongPathPrefix', () => {
+		it('is a no-op on Linux regardless of path length', () => {
+			withPlatform('linux', () => {
+				const longPath = 'a'.repeat(300);
+				expect(ensureLongPathPrefix(longPath)).toBe(longPath);
+			});
+		});
+
+		it('is a no-op on Windows for short paths', () => {
+			withPlatform('win32', () => {
+				expect(ensureLongPathPrefix('C:\\short')).toBe('C:\\short');
+			});
+		});
+
+		it('adds \\\\?\\ prefix for long Windows paths', () => {
+			withPlatform('win32', () => {
+				const longPath = 'C:\\' + 'a'.repeat(260);
+				expect(ensureLongPathPrefix(longPath)).toBe('\\\\?\\' + longPath);
+			});
+		});
+
+		it('adds \\\\?\\UNC\\ prefix for long UNC paths', () => {
+			withPlatform('win32', () => {
+				const longUNC = '\\\\server\\share\\' + 'a'.repeat(260);
+				expect(ensureLongPathPrefix(longUNC)).toBe('\\\\?\\UNC\\server\\share\\' + 'a'.repeat(260));
+			});
+		});
+
+		it('is a no-op if the path already has the \\\\?\\ prefix', () => {
+			withPlatform('win32', () => {
+				const prefixed = '\\\\?\\C:\\already\\prefixed';
+				expect(ensureLongPathPrefix(prefixed)).toBe(prefixed);
+			});
+		});
+	});
+
+	describe('isReservedWindowsFilename', () => {
+		it('returns false on Linux for any name', () => {
+			withPlatform('linux', () => {
+				expect(isReservedWindowsFilename('CON')).toBe(false);
+				expect(isReservedWindowsFilename('NUL')).toBe(false);
+			});
+		});
+
+		it('detects CON on Windows', () => {
+			withPlatform('win32', () => {
+				expect(isReservedWindowsFilename('CON')).toBe(true);
+			});
+		});
+
+		it('detects NUL on Windows', () => {
+			withPlatform('win32', () => {
+				expect(isReservedWindowsFilename('NUL')).toBe(true);
+			});
+		});
+
+		it('detects COM1-COM9 on Windows', () => {
+			withPlatform('win32', () => {
+				for (let i = 1; i <= 9; i++) {
+					expect(isReservedWindowsFilename(`COM${i}`)).toBe(true);
+				}
+			});
+		});
+
+		it('detects LPT1-LPT9 on Windows', () => {
+			withPlatform('win32', () => {
+				for (let i = 1; i <= 9; i++) {
+					expect(isReservedWindowsFilename(`LPT${i}`)).toBe(true);
+				}
+			});
+		});
+
+		it('detects reserved names with extensions on Windows', () => {
+			withPlatform('win32', () => {
+				expect(isReservedWindowsFilename('CON.txt')).toBe(true);
+				expect(isReservedWindowsFilename('NUL.md')).toBe(true);
+			});
+		});
+
+		it('is case-insensitive on Windows', () => {
+			withPlatform('win32', () => {
+				expect(isReservedWindowsFilename('con')).toBe(true);
+				expect(isReservedWindowsFilename('Con')).toBe(true);
+			});
+		});
+
+		it('returns false for normal filenames on Windows', () => {
+			withPlatform('win32', () => {
+				expect(isReservedWindowsFilename('notes.md')).toBe(false);
+				expect(isReservedWindowsFilename('com.example')).toBe(false);
+			});
+		});
+	});
+
+	describe('translateFsError', () => {
+		function mkErr(code: string, p?: string): NodeJS.ErrnoException {
+			const e = new Error('test') as NodeJS.ErrnoException;
+			e.code = code;
+			e.path = p;
+			return e;
+		}
+
+		it('translates EACCES', () => {
+			expect(translateFsError(mkErr('EACCES', '/foo'), 'read')).toMatch(/access denied/i);
+		});
+
+		it('translates ENOENT', () => {
+			expect(translateFsError(mkErr('ENOENT', '/foo/bar'), 'read')).toMatch(/not found/i);
+		});
+
+		it('translates EBUSY', () => {
+			expect(translateFsError(mkErr('EBUSY', '/foo'), 'read')).toMatch(/locked/i);
+		});
+
+		it('translates ENOSPC', () => {
+			expect(translateFsError(mkErr('ENOSPC'), 'write')).toMatch(/disk space/i);
+		});
+
+		it('translates EPERM on Windows with Developer Mode hint', () => {
+			withPlatform('win32', () => {
+				expect(translateFsError(mkErr('EPERM', '/foo'), 'write')).toMatch(/developer mode/i);
+			});
+		});
+
+		it('translates EPERM on Linux without Windows hint', () => {
+			withPlatform('linux', () => {
+				const msg = translateFsError(mkErr('EPERM', '/foo'), 'write');
+				expect(msg).not.toMatch(/developer mode/i);
+				expect(msg).toMatch(/not permitted/i);
+			});
+		});
+
+		it('translates ENAMETOOLONG on Windows with Long Paths hint', () => {
+			withPlatform('win32', () => {
+				expect(translateFsError(mkErr('ENAMETOOLONG'), 'write')).toMatch(/long paths/i);
+			});
+		});
+
+		it('translates ENAMETOOLONG on Linux without Windows hint', () => {
+			withPlatform('linux', () => {
+				expect(translateFsError(mkErr('ENAMETOOLONG'), 'write')).toMatch(/too long/i);
+			});
+		});
+
+		it('falls back to error message for unknown codes', () => {
+			const e = mkErr('EUNKNOWN');
+			e.message = 'something weird';
+			expect(translateFsError(e, 'read')).toContain('something weird');
+		});
+	});
+});

--- a/tests/PathMapper.test.ts
+++ b/tests/PathMapper.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as path from 'path';
+import { PathMapper } from '../src/PathMapper';
+import type { MountPoint } from '../src/types';
+
+function mount(virtualPath: string, realPath: string): MountPoint {
+	return { id: '1', virtualPath, realPath, enabled: true, readOnly: false };
+}
+
+describe('PathMapper', () => {
+	let mapper: PathMapper;
+
+	beforeEach(() => {
+		mapper = new PathMapper();
+	});
+
+	describe('getMountForPath', () => {
+		it('returns undefined when no mounts are loaded', () => {
+			expect(mapper.getMountForPath('foo/bar')).toBeUndefined();
+		});
+
+		it('returns the mount for an exact match', () => {
+			const m = mount('Projects/Work', '/real/Work');
+			mapper.update([m]);
+			expect(mapper.getMountForPath('Projects/Work')).toBe(m);
+		});
+
+		it('returns the mount for a child path', () => {
+			const m = mount('Projects/Work', '/real/Work');
+			mapper.update([m]);
+			expect(mapper.getMountForPath('Projects/Work/notes.md')).toBe(m);
+		});
+
+		it('returns undefined for a path outside all mounts', () => {
+			mapper.update([mount('Projects/Work', '/real/Work')]);
+			expect(mapper.getMountForPath('Documents')).toBeUndefined();
+		});
+
+		it('returns the most-specific mount when mounts overlap in specificity', () => {
+			const outer = mount('Projects', '/outer');
+			const inner = mount('Projects/Work', '/inner');
+			mapper.update([outer, inner]);
+			expect(mapper.getMountForPath('Projects/Work/file.md')).toBe(inner);
+		});
+
+		it('only considers enabled mounts', () => {
+			const disabled: MountPoint = { id: '2', virtualPath: 'Disabled', realPath: '/d', enabled: false, readOnly: false };
+			mapper.update([disabled]);
+			expect(mapper.getMountForPath('Disabled')).toBeUndefined();
+		});
+	});
+
+	describe('toRealPath', () => {
+		it('returns realPath for the mount root', () => {
+			const m = mount('Projects/Work', '/real/Work');
+			expect(mapper.toRealPath('Projects/Work', m)).toBe('/real/Work');
+		});
+
+		it('joins relative segments correctly for a child path', () => {
+			const m = mount('Projects/Work', '/real/Work');
+			const result = mapper.toRealPath('Projects/Work/notes/todo.md', m);
+			expect(result).toBe(path.join('/real/Work', 'notes', 'todo.md'));
+		});
+	});
+
+	describe('toVirtualPath', () => {
+		it('returns the virtual mount path for the real mount root', () => {
+			const m = mount('Projects/Work', '/real/Work');
+			expect(mapper.toVirtualPath('/real/Work', m)).toBe('Projects/Work');
+		});
+
+		it('converts a child real path to a virtual path', () => {
+			const m = mount('Projects/Work', '/real/Work');
+			const result = mapper.toVirtualPath(path.join('/real/Work', 'notes', 'todo.md'), m);
+			expect(result).toBe('Projects/Work/notes/todo.md');
+		});
+	});
+
+	describe('getVirtualMountsDirectChildren', () => {
+		it('returns top-level mounts at the vault root', () => {
+			mapper.update([mount('Work', '/real/Work')]);
+			expect(mapper.getVirtualMountsDirectChildren('')).toContain('Work');
+		});
+
+		it('returns the first path component for a nested mount at the vault root', () => {
+			mapper.update([mount('Projects/Work', '/real/Work')]);
+			const children = mapper.getVirtualMountsDirectChildren('');
+			expect(children).toContain('Projects');
+			expect(children).not.toContain('Projects/Work');
+		});
+
+		it('returns the full mount path when listing an intermediate directory', () => {
+			mapper.update([mount('Projects/Work', '/real/Work')]);
+			const children = mapper.getVirtualMountsDirectChildren('Projects');
+			expect(children).toContain('Projects/Work');
+		});
+
+		it('deduplicates intermediate folders for multiple nested mounts', () => {
+			mapper.update([
+				mount('Projects/Work', '/real/Work'),
+				mount('Projects/Personal', '/real/Personal'),
+			]);
+			const children = mapper.getVirtualMountsDirectChildren('');
+			const projectsCount = children.filter(c => c === 'Projects').length;
+			expect(projectsCount).toBe(1);
+		});
+
+		it('returns direct children only, not deeply nested paths', () => {
+			mapper.update([mount('A/B/C', '/real/C')]);
+			const root = mapper.getVirtualMountsDirectChildren('');
+			expect(root).toContain('A');
+			expect(root).not.toContain('A/B');
+
+			const levelA = mapper.getVirtualMountsDirectChildren('A');
+			expect(levelA).toContain('A/B');
+			expect(levelA).not.toContain('A/B/C');
+		});
+	});
+
+	describe('hasMountsUnder', () => {
+		it('returns false when no mounts loaded', () => {
+			expect(mapper.hasMountsUnder('Projects')).toBe(false);
+		});
+
+		it('returns true for a path that has a mount under it', () => {
+			mapper.update([mount('Projects/Work', '/real/Work')]);
+			expect(mapper.hasMountsUnder('Projects')).toBe(true);
+		});
+
+		it('returns false for a sibling path', () => {
+			mapper.update([mount('Projects/Work', '/real/Work')]);
+			expect(mapper.hasMountsUnder('Documents')).toBe(false);
+		});
+
+		it('returns true for the vault root when any mount exists', () => {
+			mapper.update([mount('Work', '/real/Work')]);
+			expect(mapper.hasMountsUnder('')).toBe(true);
+		});
+	});
+
+	describe('isInsideMount', () => {
+		it('returns false when path is outside all mounts', () => {
+			mapper.update([mount('Work', '/real/Work')]);
+			expect(mapper.isInsideMount('Documents')).toBe(false);
+		});
+
+		it('returns true for the mount root itself', () => {
+			mapper.update([mount('Work', '/real/Work')]);
+			expect(mapper.isInsideMount('Work')).toBe(true);
+		});
+
+		it('returns true for a path inside a mount', () => {
+			mapper.update([mount('Work', '/real/Work')]);
+			expect(mapper.isInsideMount('Work/notes.md')).toBe(true);
+		});
+	});
+});

--- a/tests/SecurityManager.test.ts
+++ b/tests/SecurityManager.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as path from 'path';
+import { SecurityManager } from '../src/SecurityManager';
+import type { MountPoint } from '../src/types';
+
+// Helper: temporarily override process.platform
+function withPlatform(platform: NodeJS.Platform, fn: () => void): void {
+	const orig = process.platform;
+	Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+	try { fn(); } finally {
+		Object.defineProperty(process, 'platform', { value: orig, configurable: true });
+	}
+}
+
+function mkMount(virtualPath: string, realPath: string): Omit<MountPoint, 'id'> {
+	return { virtualPath, realPath, enabled: true, readOnly: false };
+}
+
+describe('SecurityManager', () => {
+	let sec: SecurityManager;
+
+	beforeEach(() => {
+		sec = new SecurityManager(['/allowed/path']);
+	});
+
+	describe('isAllowed', () => {
+		it('allows an exact match to an allowlisted path', () => {
+			expect(sec.isAllowed('/allowed/path')).toBe(true);
+		});
+
+		it('allows a subdirectory of an allowlisted path', () => {
+			expect(sec.isAllowed('/allowed/path/subdir/file.md')).toBe(true);
+		});
+
+		it('rejects a path not in the allowlist', () => {
+			expect(sec.isAllowed('/not/allowed')).toBe(false);
+		});
+
+		it('rejects a prefix-substring path that is not a subdirectory', () => {
+			// /allowed/pathmore should NOT be allowed when /allowed/path is in list
+			expect(sec.isAllowed('/allowed/pathmore')).toBe(false);
+		});
+	});
+
+	describe('allow / revoke', () => {
+		it('dynamically adds a path to the allowlist', () => {
+			sec.allow('/new/path');
+			expect(sec.isAllowed('/new/path/file.txt')).toBe(true);
+		});
+
+		it('revokes an allowlisted path', () => {
+			sec.revoke('/allowed/path');
+			expect(sec.isAllowed('/allowed/path')).toBe(false);
+		});
+
+		it('does not affect other entries when revoking', () => {
+			sec.allow('/other');
+			sec.revoke('/allowed/path');
+			expect(sec.isAllowed('/other')).toBe(true);
+		});
+	});
+
+	describe('validateMount', () => {
+		it('returns null for a valid mount', () => {
+			expect(sec.validateMount(mkMount('Work', '/home/user/Work'), [])).toBeNull();
+		});
+
+		it('rejects empty virtual path', () => {
+			expect(sec.validateMount(mkMount('', '/home/user/Work'), [])).toMatch(/virtual path/i);
+		});
+
+		it('rejects empty real path', () => {
+			expect(sec.validateMount(mkMount('Work', ''), [])).toMatch(/real path/i);
+		});
+
+		it('rejects a non-absolute real path', () => {
+			expect(sec.validateMount(mkMount('Work', 'relative/path'), [])).toMatch(/absolute/i);
+		});
+
+		it('blocks the POSIX system root /', () => {
+			expect(sec.validateMount(mkMount('Root', '/'), [])).toMatch(/protected/i);
+		});
+
+		it('blocks dangerous POSIX system paths like /etc', () => {
+			expect(sec.validateMount(mkMount('Etc', '/etc'), [])).toMatch(/protected/i);
+		});
+
+		it('blocks /etc subdirectories', () => {
+			expect(sec.validateMount(mkMount('Ssl', '/etc/ssl'), [])).toMatch(/protected/i);
+		});
+
+		it('rejects a duplicate virtual path', () => {
+			const existing: MountPoint[] = [{
+				id: '1', virtualPath: 'Work', realPath: '/real/Work', enabled: true, readOnly: false,
+			}];
+			const err = sec.validateMount(mkMount('Work', '/real/Other'), existing);
+			expect(err).toMatch(/already in use/i);
+		});
+
+		it('rejects a virtual path that is a child of an existing mount', () => {
+			const existing: MountPoint[] = [{
+				id: '1', virtualPath: 'Projects', realPath: '/real/Projects', enabled: true, readOnly: false,
+			}];
+			const err = sec.validateMount(mkMount('Projects/Work', '/real/Work'), existing);
+			expect(err).toMatch(/overlaps/i);
+		});
+
+		it('rejects a real path that is a subdirectory of an existing mount real path', () => {
+			const existing: MountPoint[] = [{
+				id: '1', virtualPath: 'ParentMount', realPath: '/real/parent', enabled: true, readOnly: false,
+			}];
+			const err = sec.validateMount(mkMount('ChildMount', '/real/parent/child'), existing);
+			expect(err).toMatch(/overlaps/i);
+		});
+
+	});
+
+	describe('getPathWarnings', () => {
+		it('returns a warning for UNC paths', () => {
+			const warnings = sec.getPathWarnings('\\\\server\\share\\folder');
+			expect(warnings.length).toBeGreaterThan(0);
+			expect(warnings[0]).toMatch(/UNC|network/i);
+		});
+
+		it('returns no warnings for a normal local path', () => {
+			const warnings = sec.getPathWarnings('/home/user/docs');
+			expect(warnings).toHaveLength(0);
+		});
+	});
+
+	// Note: the Windows case-insensitive comparison (normalizeForComparison) is
+	// tested in OSHelpers.test.ts. SecurityManager delegates to that function.
+});

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -1,0 +1,10 @@
+/**
+ * Minimal stub of the Obsidian API for unit tests.
+ * Only the exports actually used by the source modules are included.
+ */
+export function normalizePath(p: string): string {
+	return p
+		.replace(/\\/g, '/')   // backslash → forward slash
+		.replace(/^\/+/, '')    // no leading slash
+		.replace(/\/+$/, '');   // no trailing slash
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import * as path from 'path';
+
+export default defineConfig({
+	test: {
+		globals: true,
+	},
+	resolve: {
+		alias: {
+			// Redirect the Obsidian Electron package to a lightweight stub
+			// so unit tests can run in a plain Node environment.
+			obsidian: path.resolve(__dirname, 'tests/__mocks__/obsidian.ts'),
+		},
+	},
+});


### PR DESCRIPTION
## Description

This PR adds a complete unit test suite for the FolderBridge plugin and improves Windows filesystem compatibility. The changes include 72 new tests covering path mapping, security validation, and OS-specific helpers, plus fixes for virtual intermediate directory handling and dry-run mode propagation.

## Related Issues

None

## Changes Made

- **Added Vitest test suite** with 72 tests across three modules:
  - `PathMapper.test.ts`: Tests for virtual↔real path translation, mount resolution, and directory traversal
  - `SecurityManager.test.ts`: Tests for allowlist enforcement, mount validation, and path warnings
  - `OSHelpers.test.ts`: Tests for Windows long paths, UNC paths, reserved filenames, and filesystem error translation

- **Improved Windows path handling**:
  - `VirtualAdapter.stat()` now returns synthetic folder stats for virtual intermediate directories (e.g., "Projects" when mount is "Projects/Work"), preventing Obsidian from treating them as non-existent
  - Added `setDryRun()` method to `VirtualAdapter` for live dry-run mode updates without plugin reload
  - Fixed dry-run setting propagation in settings UI

- **Enhanced PathMapper**:
  - `getVirtualMountsDirectChildren()` now correctly surfaces intermediate virtual directories in vault listings for nested mount paths
  - Improved deduplication of intermediate folders when multiple mounts share a parent path

- **Updated CI/CD**:
  - Added `npm test` step to both build-check and release workflows
  - Modernized release workflow to use `softprops/action-gh-release` instead of deprecated `create-release` action
  - Added ESLint check for all source files in `src/` directory

- **Documentation**:
  - Completely rewrote README.md with clearer feature descriptions, installation instructions, quick start guide, and architecture overview
  - Added CHANGELOG.md documenting v0.1.0 release with all features and fixes

- **Test infrastructure**:
  - Added `vitest.config.ts` with Obsidian API stub for unit tests
  - Created `tests/__mocks__/obsidian.ts` minimal stub for `normalizePath()`
  - Updated `package.json` with `test` script

## Type of Change

- [x] New feature (unit test suite)
- [x] Bug fix (virtual intermediate directories, dry-run propagation)
- [x] Code refactoring (PathMapper improvements)
- [x] Documentation update (README, CHANGELOG)

## Testing Performed

- [x] Built successfully with `npm run build`
- [x] No TypeScript errors
- [x] No ESLint warnings
- [x] All 72 unit tests pass with `npm test`
- [x] Tests cover Windows-specific behavior via platform mocking

### Test Environment
- **Node.js Version**: 20.x (LTS)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly

## Additional Notes

The test suite uses platform mocking to verify Windows-specific behavior (long paths, UNC paths, reserved filenames) on any OS. The `VirtualAdapter.stat()` fix ensures that nested mount paths like "Projects/Work" properly expose "Projects" as a virtual folder in Obsidian's file explorer, even if "Projects" doesn't exist on disk.

https://claude.ai/code/session_01VnQDAnZrrpoC4MsXxMPBxk