### PR TITLE
Fix vault file-tree injection so mounts appear without restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,30 @@ Extends Obsidian's single-root vault by letting you mount external folders as se
 2. Copy them to `<your-vault>/.obsidian/plugins/obsidian-folderbridge/`
 3. Enable the plugin in **Settings → Community Plugins**
 
+### Local Development (git clone)
+
+If you want to run straight from source (no release download needed):
+
+```bash
+# 1. Clone into your vault's plugin folder
+git clone https://github.com/tescolopio/Obsidian_FolderBridge.git \
+  /path/to/your-vault/.obsidian/plugins/obsidian-folderbridge
+
+cd /path/to/your-vault/.obsidian/plugins/obsidian-folderbridge
+
+# 2. Install dependencies
+npm install
+
+# 3. Build the plugin (produces main.js that Obsidian loads)
+npm run build
+```
+
+Then in Obsidian: **Settings → Community Plugins → disable Safe Mode → enable FolderBridge**.
+
+> **Hot-reload during development:** run `npm run dev` instead of `npm run build`.
+> Install the [hot-reload plugin](https://github.com/pjeby/hot-reload) in Obsidian and it will
+> automatically reload FolderBridge whenever `main.js` is rebuilt.
+
 ---
 
 ## Quick Start
@@ -42,7 +66,9 @@ Extends Obsidian's single-root vault by letting you mount external folders as se
    - **Real path** — the absolute path on disk, e.g. `C:\Users\YourName\Documents\Work` (Windows) or `/home/yourname/Documents/Work` (Linux/Mac)
 4. Click **Validate & Add**
 
-The folder now appears in Obsidian's file explorer at the virtual path you chose.
+The folder appears immediately in Obsidian's file explorer at the virtual path you chose —
+no restart needed. Files are read and written directly from their original location on disk;
+nothing is copied or moved.
 
 ---
 

--- a/main.ts
+++ b/main.ts
@@ -53,6 +53,15 @@ export default class FolderBridgePlugin extends Plugin {
 		// Settings tab
 		this.addSettingTab(new FolderBridgeSettingTab(this.app, this));
 
+		// After the workspace finishes loading, inject all enabled mounts into
+		// Obsidian's internal vault file tree so they appear in the file explorer
+		// without requiring a restart.
+		this.app.workspace.onLayoutReady(async () => {
+			for (const mount of this.settings.mountPoints.filter(m => m.enabled)) {
+				await this.notifyVaultMountAdded(mount);
+			}
+		});
+
 		console.log(`FolderBridge loaded (${getPlatform()}, ${this.settings.mountPoints.filter(m => m.enabled).length} active mounts)`);
 	}
 
@@ -127,6 +136,7 @@ export default class FolderBridgePlugin extends Plugin {
 		await this.saveSettings();
 		this.pathMapper.update(this.settings.mountPoints);
 		this.updateStatusBar();
+		await this.notifyVaultMountAdded(mount);
 
 		new Notice(`FolderBridge: Mounted "${mount.realPath}" → "${mount.virtualPath}"`);
 	}
@@ -136,6 +146,10 @@ export default class FolderBridgePlugin extends Plugin {
 		if (idx === -1) return;
 
 		const mount = this.settings.mountPoints[idx];
+
+		// Remove from vault tree BEFORE removing from pathMapper so stat() still resolves
+		await this.notifyVaultMountRemoved(mount);
+
 		this.settings.mountPoints.splice(idx, 1);
 
 		// Only revoke the allowlist entry if no other active mount shares the real path
@@ -150,6 +164,57 @@ export default class FolderBridgePlugin extends Plugin {
 		this.updateStatusBar();
 
 		new Notice(`FolderBridge: Removed mount "${mount.virtualPath}"`);
+	}
+
+	// ------------------------------------------------------------------
+	// Vault file-tree injection
+	// ------------------------------------------------------------------
+
+	/**
+	 * Notify Obsidian's internal vault index that a new virtual mount folder
+	 * exists so it appears in the file explorer without requiring a restart.
+	 *
+	 * Obsidian's internal `vault.onChange('created', path)` is the same hook
+	 * the OS file-watcher uses to signal new paths.  Because our VirtualAdapter
+	 * intercepts `adapter.stat()`, Obsidian correctly identifies each segment
+	 * as a folder and inserts it into its internal TFolder tree.
+	 */
+	async notifyVaultMountAdded(mount: MountPoint): Promise<void> {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const vault = this.app.vault as any;
+		if (typeof vault.onChange !== 'function') return;
+
+		// Walk every path segment so intermediate virtual folders also appear
+		// (e.g. mounting "Projects/Work" also surfaces the "Projects" folder).
+		const segments = normalizePath(mount.virtualPath).split('/');
+		for (let i = 1; i <= segments.length; i++) {
+			const partPath = segments.slice(0, i).join('/');
+			// Skip segments Obsidian already knows about
+			if (this.app.vault.getAbstractFileByPath(partPath)) continue;
+			try {
+				await vault.onChange('created', partPath, null, null);
+			} catch (e) {
+				console.debug('FolderBridge: vault.onChange(created) unavailable', e);
+			}
+		}
+	}
+
+	/**
+	 * Remove a virtual mount folder from Obsidian's internal vault index
+	 * so the file explorer stops showing it immediately after removal.
+	 */
+	async notifyVaultMountRemoved(mount: MountPoint): Promise<void> {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const vault = this.app.vault as any;
+		if (typeof vault.onChange !== 'function') return;
+
+		const nPath = normalizePath(mount.virtualPath);
+		if (!this.app.vault.getAbstractFileByPath(nPath)) return;
+		try {
+			await vault.onChange('deleted', nPath, null, null);
+		} catch (e) {
+			console.debug('FolderBridge: vault.onChange(deleted) unavailable', e);
+		}
 	}
 
 	// ------------------------------------------------------------------
@@ -300,6 +365,12 @@ class FolderBridgeSettingTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 					this.plugin.pathMapper.update(this.plugin.settings.mountPoints);
 					this.plugin.updateStatusBar();
+					// Inject into / remove from Obsidian's vault tree live
+					if (val) {
+						await this.plugin.notifyVaultMountAdded(mount);
+					} else {
+						await this.plugin.notifyVaultMountRemoved(mount);
+					}
 				}))
 			.addButton(btn => btn
 				.setButtonText('Remove')


### PR DESCRIPTION
- Add notifyVaultMountAdded/Removed methods that call Obsidian's internal vault.onChange('created'/'deleted', path) hook — the same hook the OS file-watcher uses — so virtual mount folders are inserted into the internal TFolder tree immediately
- Call notifyVaultMountAdded for all enabled mounts via onLayoutReady on plugin load, so saved mounts appear after enabling the plugin
- Call notify methods in addMount() and removeMount() for live add/remove
- Wire enable/disable toggle in settings to also call notify methods so toggling a mount on/off updates the file explorer instantly
- Update README: add Local Development (git clone) section with explicit npm install + npm run build steps and hot-reload instructions

https://claude.ai/code/session_01USeDvJu9spf6twNreDh8Hf

## Description
<!-- Describe what this PR does -->

## Related Issues
<!-- Link to related issues, e.g., "Closes #123" or "Relates to #456" -->

## Changes Made
<!-- List the main changes in this PR -->
- 
- 
- 

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing Performed
<!-- Describe the tests you ran and their results -->
- [ ] Built successfully with `npm run build`
- [ ] No TypeScript errors
- [ ] No ESLint warnings
- [ ] Tested in Obsidian
- [ ] Tested on multiple platforms (if applicable)

### Test Environment
- **OS**: 
- **Obsidian Version**: 
- **Node.js Version**: 

## Screenshots
<!-- If applicable, add screenshots showing before/after or new functionality -->

## Checklist
- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have tested my changes thoroughly

## Additional Notes
<!-- Any additional information that reviewers should know -->
