### PR TITLE
New Feature: Add fallbackRealPath for cross-platform vault support (Windows ↔ Linux/macOS)

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -1,0 +1,67 @@
+# FolderBridge Dev Log
+
+## Cross-Platform Vault Support (fallbackRealPath)
+
+**Date:** 2026-04-07
+**Branch:** main
+**Files changed:** `main.ts`, `src/types.ts`, `src/PathMapper.ts`, `src/SecurityManager.ts`, `src/TocConfig.ts`, `src/ui/MountManagerModal.ts`
+
+### Problem
+
+FolderBridge stores mount paths in `data.json`, which syncs across devices via Obsidian Sync or git. When a vault is created on Windows (e.g. `D:\Pauls Obsidian\Projects`), those paths are meaningless on Linux or macOS where the same folder may live at `/home/user/Obsidian/Projects`. The existing `allowForeignMounts` toggle was too blunt — it controlled visibility but gave no way to remap paths per platform.
+
+### Solution
+
+Added a `fallbackRealPath` field to `MountPoint`. When the primary `realPath` is inaccessible at plugin load, the plugin automatically tries `fallbackRealPath`. If accessible, it stores the resolved path in memory (never written to `data.json`) and uses it transparently for all I/O. This allows Windows users to set their Windows path as `realPath` and their Linux/macOS path as `fallbackRealPath` — the same `data.json` then works on both platforms with no manual intervention after the initial setup.
+
+The same fallback mechanism was also added to the managed TOC file path (`managedTocSourceFallback`), since users who configure mounts via a TOC JSON file face the identical problem.
+
+### Changes
+
+#### `src/types.ts`
+- Added `fallbackRealPath?: string` to `MountPoint` (with JSDoc)
+- Added `fallbackRealPath?: string` to `TocFileMount`
+- Added `managedTocSourceFallback?: string` to `FolderBridgeSettings`
+
+#### `src/PathMapper.ts`
+- Added `resolvedRealPaths: Map<string, string>` — runtime cache of resolved fallback paths (not persisted)
+- Added `setResolvedPath()` / `clearResolvedPath()` methods
+- Updated `getEffectiveRealPath()` priority: deviceOverride → resolvedFallback → primary path
+- `update()` cleans stale entries from the cache when mounts change
+
+#### `src/SecurityManager.ts`
+- `validateMount()`: replaced `path.isAbsolute(mount.realPath)` with cross-platform check using `path.posix.isAbsolute || path.win32.isAbsolute`. Previously, saving a mount with a Windows primary path (`D:\...`) on Linux would always fail with "Real path must be an absolute filesystem path" even when editing an existing, unchanged path.
+
+#### `src/TocConfig.ts`
+- `serializeMountToTocEntry()`: includes `fallbackRealPath` in the serialized TOC entry
+- `parseTocConfig()`: reads and validates `fallbackRealPath` from TOC JSON
+
+#### `src/ui/MountManagerModal.ts`
+- Added "Fallback real path" Setting in the local-mount section with text input and Browse button
+- Pre-populates from `editMount.fallbackRealPath` when editing an existing mount
+- Passes `fallbackRealPath` to `onSave()` callback
+- Modal-level absoluteness check also updated to use cross-platform `path.posix.isAbsolute || path.win32.isAbsolute` and only runs when the real path has actually changed (not when only the fallback changed)
+
+#### `main.ts`
+- Added `resolveMountPath()` — checks primary path accessibility, falls back to `fallbackRealPath` if needed, stores result via `pathMapper.setResolvedPath()`
+- Added `resolveAndCacheManagedTocSource()` — same fallback logic for the managed TOC file path
+- Added `managedTocSourceFallback` Browse + save UI in the settings tab
+- `addMount()` / `updateMount()`: manages `fallbackRealPath` in the security allowlist
+- `isMountEnabledOnThisDevice()`: now also returns `true` when `fallbackRealPath` is set, so cross-platform mounts activate on foreign devices without requiring `allowForeignMounts`
+- `syncEffectiveMountState()`: includes `fallbackRealPath` in the allowlist sync
+
+### How to use
+
+1. Open Settings → FolderBridge → edit a mount
+2. In the "Real path" field, keep your Windows path (e.g. `D:\Pauls Obsidian\Projects`)
+3. In the new "Fallback real path" field, enter your Linux/macOS path (e.g. `/home/user/Obsidian/Projects`)
+4. Save — the plugin will use whichever path is accessible on each device
+
+For the managed TOC file, set the fallback path in Settings → FolderBridge → "Managed TOC source" section.
+
+### Platform coverage
+
+This fix benefits all three platforms:
+- **Windows → Linux**: primary Windows path skipped, fallback Linux POSIX path used
+- **Windows → macOS**: primary Windows path skipped, fallback macOS POSIX path used
+- **Linux/macOS → Windows**: primary POSIX path skipped, fallback Windows path used

--- a/main.ts
+++ b/main.ts
@@ -20,6 +20,7 @@ import { SFTPAdapter } from './src/SFTPAdapter';
 import { logger } from './src/logger';
 import { loadOptionalNodeModule } from './src/runtimeNode';
 import { replayMountContentsToVault } from './src/mountScan';
+import { CachedEntry, ScanCacheFile, isCacheFresh, loadScanCache, replayCacheToVault, saveScanCache } from './src/scanCache';
 import { parseTocConfig, serializeTocConfig } from './src/TocConfig';
 
 // Lazy-loaded Node.js builtins — safe on Obsidian Mobile (Capacitor).
@@ -109,6 +110,10 @@ export default class FolderBridgePlugin extends Plugin {
 	/** Tracks reachability per mount.id; populated by the 30-second health-check loop. */
 	mountHealthMap = new Map<string, boolean>();
 	private healthCheckInterval: ReturnType<typeof setInterval> | null = null;
+
+	/** Persistent scan cache — speeds up subsequent startups for large mounts. */
+	private scanCachePath: string | null = null;
+	private scanCacheData: ScanCacheFile | null = null;
 
 	isTocManagedMount(mount: MountPoint): boolean {
 		return typeof mount.tocSourcePath === 'string' && mount.tocSourcePath.length > 0;
@@ -556,6 +561,10 @@ export default class FolderBridgePlugin extends Plugin {
 			this.updateStatusBar();
 		}
 
+		this.scanCachePath = normalizePath(
+			`${this.app.vault.configDir}/plugins/folderbridge/scan-cache.json`
+		);
+
 		// Settings tab
 		this.addSettingTab(new FolderBridgeSettingTab(this.app, this));
 
@@ -859,11 +868,72 @@ export default class FolderBridgePlugin extends Plugin {
 					}
 				}
 
-				for (const mount of activeMounts) {
-					await this.notifyVaultMountAdded(mount);
-				}
-				// Start background reachability checks after initial mount injection
+				// Start background reachability checks — doesn't depend on scan state
 				this.startHealthChecks();
+
+				// Load persistent scan cache and do an instant vault replay for each
+				// mount whose cached tree is still fresh. The background scan below then
+				// only fires vault.onChange for genuinely new/changed entries.
+				if (this.scanCachePath) {
+					this.scanCacheData = await loadScanCache(this.app.vault.adapter, this.scanCachePath);
+				}
+				if (!this.scanCacheData) {
+					this.scanCacheData = { version: 1, mounts: [] };
+				}
+
+				// 24 hours for local mounts; 1 hour for cloud mounts.
+				const LOCAL_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+				const CLOUD_CACHE_MAX_AGE_MS = 60 * 60 * 1000;
+
+				for (const mount of activeMounts) {
+					const mountCache = this.scanCacheData.mounts.find(c => c.mountId === mount.id);
+					if (!mountCache) continue;
+					const isCloud = ['webdav', 's3', 'sftp'].includes(mount.mountType ?? '');
+					const maxAge = isCloud ? CLOUD_CACHE_MAX_AGE_MS : LOCAL_CACHE_MAX_AGE_MS;
+					if (!isCacheFresh(mountCache, maxAge)) continue;
+
+					const vault = this.app.vault as typeof this.app.vault & VaultInternal;
+					await replayCacheToVault(mountCache, {
+						hasAbstractFile: (p) => !!this.app.vault.getAbstractFileByPath(p),
+						onFolderCreated: (p) => vault.onChange('folder-created', p, null, null),
+						onFileCreated: (p) => vault.onChange('file-created', p, null, null),
+					});
+				}
+
+				// Fire all mount scans concurrently without blocking startup.
+				// notifyVaultMountAdded is idempotent (hasAbstractFile guards every
+				// vault.onChange call), so concurrent scans are safe.
+				// After each scan, accumulate the discovered entries and persist the cache.
+				const scanCacheData = this.scanCacheData;
+				const scanCachePath = this.scanCachePath;
+				const vaultAdapter = this.app.vault.adapter;
+
+				const scanPromises = activeMounts.map(mount => {
+					const scannedEntries: CachedEntry[] = [];
+					return this.notifyVaultMountAdded(mount, (entry) => {
+						scannedEntries.push(entry);
+					}).catch((err: unknown) => {
+						logger.error(`Folder Bridge: Startup scan failed for "${mount.virtualPath}"`, err);
+						new Notice(`Folder Bridge: startup scan failed for "${mount.virtualPath}". Check the developer console.`);
+					}).finally(() => {
+						if (scannedEntries.length === 0 || !scanCachePath) return;
+						// Update the in-memory cache for this mount
+						const existingIdx = scanCacheData.mounts.findIndex(c => c.mountId === mount.id);
+						const mountCache = {
+							mountId: mount.id,
+							virtualPath: mount.virtualPath,
+							savedAt: Date.now(),
+							entries: scannedEntries,
+						};
+						if (existingIdx >= 0) {
+							scanCacheData.mounts[existingIdx] = mountCache;
+						} else {
+							scanCacheData.mounts.push(mountCache);
+						}
+						void saveScanCache(vaultAdapter, scanCachePath, scanCacheData);
+					});
+				});
+				void Promise.all(scanPromises);
 
 				// Show first-run welcome modal for new users
 				if (!this.settings.hasSeenOnboarding) {
@@ -942,6 +1012,11 @@ export default class FolderBridgePlugin extends Plugin {
 
 		// Stop the localhost streaming server
 		this.fileServer.stop();
+
+		// Best-effort flush of the scan cache
+		if (this.scanCacheData && this.scanCachePath) {
+			void saveScanCache(this.app.vault.adapter, this.scanCachePath, this.scanCacheData);
+		}
 
 		logger.debug('Folder Bridge Unloaded');
 	}
@@ -1514,6 +1589,12 @@ export default class FolderBridgePlugin extends Plugin {
 		this.syncEffectiveMountState();
 		this.updateStatusBar();
 
+		// Evict the removed mount from the persistent scan cache
+		if (this.scanCacheData && this.scanCachePath) {
+			this.scanCacheData.mounts = this.scanCacheData.mounts.filter(c => c.mountId !== mount.id);
+			void saveScanCache(this.app.vault.adapter, this.scanCachePath, this.scanCacheData);
+		}
+
 		new Notice(`Folder Bridge: Removed mount "${mount.virtualPath}".`);
 	}
 
@@ -1798,7 +1879,10 @@ export default class FolderBridgePlugin extends Plugin {
 	 * intercepts `adapter.stat()`, Obsidian correctly identifies each segment
 	 * as a folder and inserts it into its internal TFolder tree.
 	 */
-	async notifyVaultMountAdded(mount: MountPoint): Promise<void> {
+	async notifyVaultMountAdded(
+		mount: MountPoint,
+		onEntryScanned?: (entry: { path: string; type: 'file' | 'folder'; mtime?: number; size?: number }) => void,
+	): Promise<void> {
 		// Resolve primary vs fallback path before any I/O so PathMapper
 		// returns the correct real path for all subsequent operations.
 		await this.resolveMountPath(mount);
@@ -1841,6 +1925,7 @@ export default class FolderBridgePlugin extends Plugin {
 			onError: (folderPath, error) => {
 				logger.debug(`Folder Bridge: Failed to list ${folderPath}`, error);
 			},
+			onEntryScanned,
 		});
 		notice.hide();
 		if (scanLimitHit) {

--- a/main.ts
+++ b/main.ts
@@ -6,7 +6,7 @@ import { SecurityManager } from './src/SecurityManager';
 import { MountManagerModal, getMountStatus, browseFolderOnDisk, browseMultipleFoldersOnDisk, VaultFolderPickerModal } from './src/ui/MountManagerModal';
 import { MountRootDeleteModal } from './src/ui/MountRootDeleteModal';
 import { WelcomeModal } from './src/ui/WelcomeModal';
-import { getPlatform, realPathToResourceUrl, tryReadAsDataUri } from './src/OSHelpers';
+import { getPlatform, realPathToResourceUrl, tryReadAsDataUri, checkPathAccessible } from './src/OSHelpers';
 import { FileServer } from './src/FileServer';
 import {
 	encryptCredential, decryptCredential,
@@ -90,6 +90,8 @@ export default class FolderBridgePlugin extends Plugin {
 	private managedTocMountPoints: MountPoint[] = [];
 	private externalTocMountPoints: MountPoint[] = [];
 	private tocWarnings: string[] = [];
+	/** Runtime-resolved managed TOC path (primary or fallback, whichever is accessible). */
+	resolvedManagedTocSource = '';
 	/** Localhost HTTP server — streams video/audio from local mounts with range-request support. */
 	fileServer: FileServer = new FileServer();
 
@@ -120,13 +122,93 @@ export default class FolderBridgePlugin extends Plugin {
 		return !this.isTocManagedMount(mount) || this.isManagedTocMount(mount);
 	}
 
+	/**
+	 * Returns true if a mount should be considered active on the current device.
+	 *
+	 * A mount is active on this device if:
+	 *  1. It was created on this device (deviceId matches), OR
+	 *  2. The user has opted in to all foreign mounts (allowForeignMounts), OR
+	 *  3. The user has explicitly set a path override for this device
+	 *     (deviceOverrides[currentDeviceId] exists), OR
+	 *  4. The mount has a fallbackRealPath configured — the user has deliberately
+	 *     opted this mount in for cross-platform use without needing per-device setup.
+	 */
+	isMountEnabledOnThisDevice(mount: MountPoint): boolean {
+		if (mount.deviceId === this.settings.deviceId) return true;
+		if (this.settings.allowForeignMounts) return true;
+		if (mount.deviceOverrides?.[this.settings.deviceId]) return true;
+		if (mount.fallbackRealPath) return true;
+		return false;
+	}
+
+	/**
+	 * Resolves the real filesystem path for a local mount by checking whether the
+	 * primary realPath is accessible, and falling back to fallbackRealPath if not.
+	 * Stores the result in PathMapper so all subsequent I/O uses the correct path.
+	 * No-op for cloud mounts (WebDAV/S3/SFTP) and when a device override is set.
+	 */
+	private async resolveMountPath(mount: MountPoint): Promise<void> {
+		if (this.isCloudMount(mount)) return;
+		// Device override takes highest priority — PathMapper already handles it
+		if (mount.deviceOverrides?.[this.settings.deviceId]) return;
+		if (!mount.fallbackRealPath) return;
+
+		const { accessible } = await checkPathAccessible(mount.realPath);
+		if (accessible) {
+			this.pathMapper.clearResolvedPath(mount.id);
+			return;
+		}
+		const fallback = await checkPathAccessible(mount.fallbackRealPath);
+		if (fallback.accessible) {
+			this.pathMapper.setResolvedPath(mount.id, mount.fallbackRealPath);
+			logger.debug(`Folder Bridge: using fallback path "${mount.fallbackRealPath}" for "${mount.virtualPath}" (primary "${mount.realPath}" not accessible)`);
+		}
+	}
+
 	getTocWarnings(): string[] {
 		return [...this.tocWarnings];
 	}
 
 	private getManagedTocSourcePath(): string | null {
+		// Use runtime-resolved path (primary or fallback, whichever was accessible at load time)
+		if (this.resolvedManagedTocSource) return this.resolvedManagedTocSource;
 		const sourcePath = this.settings.managedTocSource?.trim();
 		return sourcePath ? sourcePath : null;
+	}
+
+	/**
+	 * Resolves which managed TOC file to use: checks the primary path first,
+	 * then falls back to managedTocSourceFallback if the primary isn't accessible.
+	 * Result is cached in resolvedManagedTocSource for the session.
+	 */
+	async resolveAndCacheManagedTocSource(): Promise<void> {
+		const primary = this.settings.managedTocSource?.trim();
+		const fallback = this.settings.managedTocSourceFallback?.trim();
+
+		if (!primary && !fallback) {
+			this.resolvedManagedTocSource = '';
+			return;
+		}
+
+		if (primary) {
+			const { accessible } = await checkPathAccessible(primary);
+			if (accessible) {
+				this.resolvedManagedTocSource = primary;
+				return;
+			}
+		}
+
+		if (fallback) {
+			const { accessible } = await checkPathAccessible(fallback);
+			if (accessible) {
+				this.resolvedManagedTocSource = fallback;
+				logger.debug(`Folder Bridge: using fallback TOC source "${fallback}" (primary "${primary}" not accessible)`);
+				return;
+			}
+		}
+
+		// Neither accessible — fall back to primary (will produce a load warning)
+		this.resolvedManagedTocSource = primary || fallback || '';
 	}
 
 	private isManagedTocSource(sourcePath?: string): boolean {
@@ -197,12 +279,15 @@ export default class FolderBridgePlugin extends Plugin {
 		}
 
 		const previousSource = this.settings.managedTocSource;
+		const previousResolved = this.resolvedManagedTocSource;
 		this.settings.managedTocSource = trimmedPath;
+		this.resolvedManagedTocSource = trimmedPath; // explicit bind always uses the provided path
 		this.settings.tocSources = this.settings.tocSources.filter(item => item.trim() !== trimmedPath);
 
 		try {
 			if (!await this.writeManagedTocMounts(this.getManagedTocDraftMounts())) {
 				this.settings.managedTocSource = previousSource;
+				this.resolvedManagedTocSource = previousResolved;
 				return false;
 			}
 			await this.refreshTocMountSources(true);
@@ -210,6 +295,7 @@ export default class FolderBridgePlugin extends Plugin {
 			return true;
 		} catch (error) {
 			this.settings.managedTocSource = previousSource;
+			this.resolvedManagedTocSource = previousResolved;
 			const message = error instanceof Error ? error.message : String(error);
 			new Notice(`Folder Bridge: Failed to initialize managed TOC file (${message}).`);
 			return false;
@@ -244,6 +330,7 @@ export default class FolderBridgePlugin extends Plugin {
 		this.persistedMountPoints.push(...this.getManagedTocDraftMounts());
 		this.managedTocMountPoints = [];
 		this.settings.managedTocSource = '';
+		this.resolvedManagedTocSource = '';
 		await this.refreshTocMountSources();
 		await this.saveSettings();
 		return true;
@@ -324,8 +411,11 @@ export default class FolderBridgePlugin extends Plugin {
 			...this.persistedAllowlist,
 			...effectiveMounts
 				.filter(m => !this.isCloudMount(m))
-				.map(m => this.effectiveRealPathForAllowlist(m))
-				.filter(Boolean),
+				.flatMap(m => [
+					this.effectiveRealPathForAllowlist(m),
+					m.fallbackRealPath,
+				])
+				.filter((p): p is string => !!p),
 		]));
 
 		this.settings.mountPoints = effectiveMounts;
@@ -475,7 +565,7 @@ export default class FolderBridgePlugin extends Plugin {
 			name: 'Refresh all mounts',
 			callback: () => {
 				void (async () => {
-					for (const mount of this.settings.mountPoints.filter(m => m.enabled && (m.deviceId === this.settings.deviceId || this.settings.allowForeignMounts))) {
+					for (const mount of this.settings.mountPoints.filter(m => m.enabled && this.isMountEnabledOnThisDevice(m))) {
 						await this.notifyVaultMountAdded(mount);
 					}
 					new Notice(`${this.manifest.name}: mounts refreshed`);
@@ -508,7 +598,7 @@ export default class FolderBridgePlugin extends Plugin {
 			name: 'Toggle mount on/off…',
 			callback: () => {
 				const myMounts = this.settings.mountPoints.filter(
-					m => this.isUserEditableMount(m) && (m.deviceId === this.settings.deviceId || this.settings.allowForeignMounts),
+					m => this.isUserEditableMount(m) && this.isMountEnabledOnThisDevice(m),
 				);
 				if (myMounts.length === 0) {
 					new Notice(`${this.manifest.name}: no mounts configured.`);
@@ -597,7 +687,7 @@ export default class FolderBridgePlugin extends Plugin {
 			name: 'Toggle read-only on a specific mount…',
 			callback: () => {
 				const myMounts = this.settings.mountPoints.filter(
-					m => this.isUserEditableMount(m) && (m.deviceId === this.settings.deviceId || this.settings.allowForeignMounts),
+					m => this.isUserEditableMount(m) && this.isMountEnabledOnThisDevice(m),
 				);
 				if (myMounts.length === 0) {
 					new Notice(`${this.manifest.name}: no mounts configured.`);
@@ -638,7 +728,7 @@ export default class FolderBridgePlugin extends Plugin {
 			name: 'Toggle watcher event suppression for a specific mount…',
 			callback: () => {
 				const myMounts = this.settings.mountPoints.filter(
-					m => m.deviceId === this.settings.deviceId || this.settings.allowForeignMounts,
+					m => this.isMountEnabledOnThisDevice(m),
 				);
 				if (myMounts.length === 0) {
 					new Notice(`${this.manifest.name}: no mounts configured.`);
@@ -734,7 +824,7 @@ export default class FolderBridgePlugin extends Plugin {
 			void (async () => {
 				// [BUGFIX_20260222] Removed debug log for resource path format
 
-				const activeMounts = this.settings.mountPoints.filter(m => m.enabled && (m.deviceId === this.settings.deviceId || this.settings.allowForeignMounts));
+				const activeMounts = this.settings.mountPoints.filter(m => m.enabled && this.isMountEnabledOnThisDevice(m));
 
 				// Register adapters for all active mounts — each type handled in its own branch.
 				for (const mount of activeMounts) {
@@ -789,11 +879,28 @@ export default class FolderBridgePlugin extends Plugin {
 						).open(),
 						() => { /* dismissed */ },
 					).open();
+				} else {
+					// Warn when mounts from another device have no path configured for this device.
+					// Mounts with a fallbackRealPath or explicit device override activate automatically.
+					const unmappedForeignMounts = this.settings.mountPoints.filter(m =>
+						m.enabled &&
+						m.deviceId !== this.settings.deviceId &&
+						!m.deviceOverrides?.[this.settings.deviceId] &&
+						!m.fallbackRealPath
+					);
+					if (unmappedForeignMounts.length > 0) {
+						new Notice(
+							`Folder Bridge: ${unmappedForeignMounts.length} mount(s) from another device ` +
+							`are inactive on this device. Open Settings → Folder Bridge and use ` +
+							`"Set path for this device" on each mount to activate them here.`,
+							10000
+						);
+					}
 				}
 			})();
 		});
 
-		logger.debug(`Folder Bridge Loaded (${getPlatform()}, ${this.settings.mountPoints.filter(m => m.enabled && (m.deviceId === this.settings.deviceId || this.settings.allowForeignMounts)).length} active mounts on this device)`);
+		logger.debug(`Folder Bridge Loaded (${getPlatform()}, ${this.settings.mountPoints.filter(m => m.enabled && this.isMountEnabledOnThisDevice(m)).length} active mounts on this device)`);
 	}
 
 	onunload() {
@@ -1256,6 +1363,11 @@ export default class FolderBridgePlugin extends Plugin {
 			this.persistedAllowlist.push(mount.realPath);
 			this.security.allow(mount.realPath);
 		}
+		// Also allow the fallback path if one is configured
+		if (!isCloud && mount.fallbackRealPath && !this.persistedAllowlist.includes(mount.fallbackRealPath)) {
+			this.persistedAllowlist.push(mount.fallbackRealPath);
+			this.security.allow(mount.fallbackRealPath);
+		}
 
 		// Wire up WebDAV adapter
 		if (mount.mountType === 'webdav') {
@@ -1548,6 +1660,26 @@ export default class FolderBridgePlugin extends Plugin {
 			}
 		}
 
+		// Keep fallback path in the allowlist when it changes (local mounts only)
+		const fallbackChanged = (oldMount.fallbackRealPath ?? '') !== (newData.fallbackRealPath ?? '');
+		if (fallbackChanged && !newIsCloud) {
+			// Remove old fallback from allowlist if nothing else uses it
+			if (oldMount.fallbackRealPath) {
+				const stillUsed = otherMounts.some(m =>
+					m.realPath === oldMount.fallbackRealPath || m.fallbackRealPath === oldMount.fallbackRealPath
+				);
+				if (!stillUsed) {
+					this.persistedAllowlist = this.persistedAllowlist.filter(p => p !== oldMount.fallbackRealPath);
+					this.security.revoke(oldMount.fallbackRealPath);
+				}
+			}
+			// Allow the new fallback path
+			if (newData.fallbackRealPath && !this.persistedAllowlist.includes(newData.fallbackRealPath)) {
+				this.persistedAllowlist.push(newData.fallbackRealPath);
+				this.security.allow(newData.fallbackRealPath);
+			}
+		}
+
 		// Preserve id, deviceId, ignoreList, and deviceOverrides from the original
 		this.persistedMountPoints[idx] = {
 			...oldMount,
@@ -1561,8 +1693,11 @@ export default class FolderBridgePlugin extends Plugin {
 
 		const updatedMount = this.persistedMountPoints[idx];
 
-		// Re-inject when enabled and something structural changed
-		if (wasEnabled && (virtualPathChanged || realPathChanged || visibleFileFilterChanged)) {
+		// Re-inject when enabled and something structural changed.
+		// Also re-inject when fallbackRealPath is newly set, so the mount activates
+		// immediately on this device if the primary path is inaccessible (cross-platform).
+		const shouldReinject = wasEnabled && (virtualPathChanged || realPathChanged || visibleFileFilterChanged || fallbackChanged);
+		if (shouldReinject) {
 			backgroundTask(this.notifyVaultMountAdded(updatedMount), `Failed to refresh edited mount "${updatedMount.virtualPath}" in the vault tree.`);
 		}
 
@@ -1578,7 +1713,7 @@ export default class FolderBridgePlugin extends Plugin {
 			oldMount.watcherDebounceMs !== updatedMount.watcherDebounceMs ||
 			oldMount.watcherUsePolling !== updatedMount.watcherUsePolling ||
 			oldMount.watcherPollingIntervalMs !== updatedMount.watcherPollingIntervalMs;
-		if ((realPathChanged || watcherSettingsChanged) && wasEnabled) {
+		if ((realPathChanged || fallbackChanged || watcherSettingsChanged) && wasEnabled) {
 			this.fileWatcher?.stopWatching(oldMount);
 			this.fileWatcher?.startWatching(updatedMount);
 		}
@@ -1664,6 +1799,10 @@ export default class FolderBridgePlugin extends Plugin {
 	 * as a folder and inserts it into its internal TFolder tree.
 	 */
 	async notifyVaultMountAdded(mount: MountPoint): Promise<void> {
+		// Resolve primary vs fallback path before any I/O so PathMapper
+		// returns the correct real path for all subsequent operations.
+		await this.resolveMountPath(mount);
+
 		const vault = this.app.vault as typeof this.app.vault & VaultInternal;
 
 		if (typeof vault.onChange !== 'function') {
@@ -1857,7 +1996,7 @@ export default class FolderBridgePlugin extends Plugin {
 			if (typeof document !== 'undefined' && document.hidden) return;
 
 			const activeMounts = this.settings.mountPoints.filter(
-				m => m.enabled && (m.deviceId === this.settings.deviceId || this.settings.allowForeignMounts)
+				m => m.enabled && this.isMountEnabledOnThisDevice(m)
 			);
 
 			let anyChanged = false;
@@ -2042,6 +2181,7 @@ export default class FolderBridgePlugin extends Plugin {
 		}
 
 		this.syncEffectiveMountState();
+		await this.resolveAndCacheManagedTocSource();
 		await this.refreshTocMountSources();
 		await this.saveSettings();
 		this.updateIgnoreCache();
@@ -2421,12 +2561,61 @@ class FolderBridgeSettingTab extends PluginSettingTab {
 					: 'No managed TOC file configured. UI-created local and vault mounts will stay in data.json until you set one.',
 				cls: 'setting-item-description',
 			});
+
+			// Show when fallback is active
+			const resolvedToc = this.plugin.resolvedManagedTocSource;
+			if (currentPath && resolvedToc && resolvedToc !== currentPath) {
+				managedTocContainer.createEl('p', {
+					text: `Using fallback TOC file on this device: ${resolvedToc}`,
+					cls: 'setting-item-description',
+				});
+			}
+
 			if (!currentPath && suggestedPath) {
 				managedTocContainer.createEl('p', {
 					text: `Suggested location: ${suggestedPath}`,
 					cls: 'setting-item-description',
 				});
 			}
+
+			// Fallback TOC path (for cross-platform vaults)
+			const fallbackRow = managedTocContainer.createDiv('folderbridge-ignore-add');
+			const fallbackLabel = fallbackRow.createEl('span', {
+				text: 'Fallback TOC path: ',
+				cls: 'setting-item-description',
+			});
+			fallbackLabel.style.whiteSpace = 'nowrap';
+			const fallbackInput = fallbackRow.createEl('input', {
+				type: 'text',
+				placeholder: 'Alternative path for this platform (e.g. /home/me/folderbridge.managed.json)',
+			});
+			fallbackInput.style.flex = '1';
+			fallbackInput.value = this.plugin.settings.managedTocSourceFallback ?? '';
+			const fallbackBrowseBtn = fallbackRow.createEl('button', { text: 'Browse…' });
+			fallbackBrowseBtn.onclick = () => {
+				void (async () => {
+					const selected = await browseFolderOnDisk('Select fallback TOC folder');
+					if (selected && path) {
+						// User picks a folder — append the same filename as the primary source
+						const primaryFilename = this.plugin.settings.managedTocSource
+							? path.basename(this.plugin.settings.managedTocSource)
+							: 'folderbridge.managed.json';
+						fallbackInput.value = path.join(selected, primaryFilename);
+					}
+				})();
+			};
+			const fallbackSaveBtn = fallbackRow.createEl('button', { text: 'Set fallback' });
+			fallbackSaveBtn.onclick = () => {
+				void (async () => {
+					const newFallback = fallbackInput.value.trim() || undefined;
+					this.plugin.settings.managedTocSourceFallback = newFallback;
+					await this.plugin.resolveAndCacheManagedTocSource();
+					await this.plugin.refreshTocMountSources(true);
+					await this.plugin.saveSettings();
+					this.display();
+					new Notice(`${this.plugin.manifest.name}: TOC fallback path ${newFallback ? 'set' : 'cleared'}.`);
+				})();
+			};
 
 			const addRow = managedTocContainer.createDiv('folderbridge-ignore-add');
 			const inputEl = addRow.createEl('input', {
@@ -2679,7 +2868,7 @@ class FolderBridgeSettingTab extends PluginSettingTab {
 	/** Render a single mount row synchronously, then patch status asynchronously. */
 	private renderMountRow(containerEl: HTMLElement, mount: MountPoint): void {
 		const isThisDevice = mount.deviceId === this.plugin.settings.deviceId;
-		const canEnable = isThisDevice || this.plugin.settings.allowForeignMounts;
+		const canEnable = this.plugin.isMountEnabledOnThisDevice(mount);
 		const isTocManaged = this.plugin.isTocManagedMount(mount);
 		const isManagedToc = this.plugin.isManagedTocMount(mount);
 		const isUserEditable = this.plugin.isUserEditableMount(mount);
@@ -2697,7 +2886,13 @@ class FolderBridgeSettingTab extends PluginSettingTab {
 
 		const effectivePath = this.plugin.pathMapper.getEffectiveRealPath(mount);
 		if (effectivePath !== mount.realPath) {
-			desc += `\n(Overridden on this device: ${effectivePath})`;
+			// Check whether the effective path came from a device override or the fallback
+			const isFromDeviceOverride = mount.deviceOverrides?.[this.plugin.settings.deviceId] === effectivePath;
+			desc += isFromDeviceOverride
+				? `\n(Path override for this device: ${effectivePath})`
+				: `\n(Using fallback path: ${effectivePath})`;
+		} else if (mount.fallbackRealPath && effectivePath === mount.realPath) {
+			desc += `\n(Fallback configured: ${mount.fallbackRealPath})`;
 		}
 
 		const setting = new Setting(containerEl)
@@ -2776,8 +2971,8 @@ class FolderBridgeSettingTab extends PluginSettingTab {
 
 		const addOverridePathButton = (): void => {
 			setting.addButton(btn => btn
-				.setButtonText('Override path')
-				.setTooltip('Set a different real path for this device')
+				.setButtonText('Set path for this device')
+				.setTooltip('Set the real folder path for this mount on this device (e.g. after moving from Windows to Linux)')
 				.onClick(() => {
 					void (async () => {
 						const newPath = await browseFolderOnDisk('Select real folder for this device');
@@ -2796,9 +2991,11 @@ class FolderBridgeSettingTab extends PluginSettingTab {
 							if (mount.enabled) {
 								this.plugin.fileWatcher?.stopWatching(mount);
 								this.plugin.fileWatcher?.startWatching(mount);
+								// Inject into vault now that this device has an explicit path override
+								await this.plugin.notifyVaultMountAdded(mount);
 							}
 							this.display();
-							new Notice(`${this.plugin.manifest.name}: path overridden for this device.`);
+							new Notice(`${this.plugin.manifest.name}: path set for this device. Mount is now active.`);
 						}
 					})();
 				}));

--- a/src/PathMapper.ts
+++ b/src/PathMapper.ts
@@ -28,6 +28,14 @@ export class PathMapper {
 		normalizedVirtualPath: string;
 	}> = [];
 
+	/**
+	 * Runtime-resolved real paths, keyed by mount ID.
+	 * Populated once at mount activation when fallbackRealPath is used
+	 * (primary path inaccessible, fallback accessible).
+	 * Never written to data.json — reset on each session.
+	 */
+	private resolvedRealPaths: Map<string, string> = new Map();
+
 	/** Replace the active mount list (call after settings change). */
 	update(mounts: MountPoint[], deviceId: string = ''): void {
 		this.currentDeviceId = deviceId;
@@ -38,6 +46,24 @@ export class PathMapper {
 		this.sortedMountCache = this.mounts
 			.map(m => ({ mount: m, normalizedVirtualPath: normalizePath(m.virtualPath) }))
 			.sort((a, b) => b.normalizedVirtualPath.length - a.normalizedVirtualPath.length);
+		// Remove runtime-resolved paths for mounts no longer active
+		const activeIds = new Set(this.mounts.map(m => m.id));
+		for (const id of this.resolvedRealPaths.keys()) {
+			if (!activeIds.has(id)) this.resolvedRealPaths.delete(id);
+		}
+	}
+
+	/**
+	 * Store a runtime-resolved real path for a mount (used when the fallback
+	 * path was selected at activation time because the primary was inaccessible).
+	 */
+	setResolvedPath(mountId: string, resolvedPath: string): void {
+		this.resolvedRealPaths.set(mountId, resolvedPath);
+	}
+
+	/** Clear a previously stored runtime-resolved path (primary is accessible again). */
+	clearResolvedPath(mountId: string): void {
+		this.resolvedRealPaths.delete(mountId);
 	}
 
 	getMounts(): MountPoint[] {
@@ -45,12 +71,18 @@ export class PathMapper {
 	}
 
 	/**
-	 * Gets the effective real path for a mount on this specific device,
-	 * falling back to the original realPath if no override exists.
+	 * Gets the effective real path for a mount on this specific device.
+	 * Priority:
+	 *   1. Explicit per-device override (deviceOverrides[currentDeviceId])
+	 *   2. Runtime-resolved fallback (set at activation when primary was inaccessible)
+	 *   3. Primary realPath
 	 */
 	getEffectiveRealPath(mount: MountPoint): string {
-		if (this.currentDeviceId && mount.deviceOverrides && mount.deviceOverrides[this.currentDeviceId]) {
+		if (this.currentDeviceId && mount.deviceOverrides?.[this.currentDeviceId]) {
 			return mount.deviceOverrides[this.currentDeviceId];
+		}
+		if (this.resolvedRealPaths.has(mount.id)) {
+			return this.resolvedRealPaths.get(mount.id)!;
 		}
 		return mount.realPath;
 	}

--- a/src/SecurityManager.ts
+++ b/src/SecurityManager.ts
@@ -65,7 +65,7 @@ export class SecurityManager {
 			if (!mount.realPath || !mount.realPath.trim()) {
 				return 'Real path cannot be empty.';
 			}
-			if (!path.isAbsolute(mount.realPath)) {
+			if (!path.posix.isAbsolute(mount.realPath) && !path.win32.isAbsolute(mount.realPath)) {
 				return 'Real path must be an absolute filesystem path.';
 			}
 

--- a/src/TocConfig.ts
+++ b/src/TocConfig.ts
@@ -57,6 +57,7 @@ export function serializeMountToTocEntry(mount: MountPoint): TocFileMount {
         deviceId: mount.deviceId,
         virtualPath: normalizeVirtualPath(mount.virtualPath),
         realPath: mount.realPath,
+        fallbackRealPath: mount.fallbackRealPath,
         label: mount.label,
         enabled: mount.enabled,
         readOnly: mount.readOnly,
@@ -142,6 +143,9 @@ export function parseTocConfig(text: string, sourcePath: string, deviceId: strin
                 : buildTocMountId(sourcePath, mount, index),
             virtualPath,
             realPath,
+            fallbackRealPath: typeof mount.fallbackRealPath === 'string' && mount.fallbackRealPath.trim()
+                ? mount.fallbackRealPath.trim()
+                : undefined,
             enabled: mount.enabled ?? true,
             readOnly: mount.readOnly ?? false,
             label: typeof mount.label === 'string' && mount.label.trim() ? mount.label.trim() : undefined,

--- a/src/mountScan.ts
+++ b/src/mountScan.ts
@@ -14,6 +14,8 @@ export interface MountScanDependencies {
     onHugeMount?(): void;
     onError?(folderPath: string, error: unknown): void;
     yieldToEventLoop?(this: void): Promise<void>;
+    /** Called after each folder or file is successfully notified to the vault. */
+    onEntryScanned?(entry: { path: string; type: 'file' | 'folder'; mtime?: number; size?: number }): void;
 }
 
 export interface MountScanResult {
@@ -71,6 +73,7 @@ export async function replayMountContentsToVault(
                 if (!deps.hasAbstractFile(folder)) {
                     await deps.onFolderCreated(folder);
                     folderCount++;
+                    deps.onEntryScanned?.({ path: folder, type: 'folder' });
                     if (scanLimit > 0 && fileCount + folderCount >= scanLimit) {
                         scanLimitHit = true;
                         return;
@@ -102,6 +105,7 @@ export async function replayMountContentsToVault(
                     const stat = await deps.stat(file);
                     await deps.onFileCreated(file, stat);
                     fileCount++;
+                    deps.onEntryScanned?.({ path: file, type: 'file', mtime: stat?.mtime, size: stat?.size });
                     if (scanLimit > 0 && fileCount + folderCount >= scanLimit) {
                         scanLimitHit = true;
                         break;

--- a/src/scanCache.ts
+++ b/src/scanCache.ts
@@ -1,0 +1,89 @@
+import { DataAdapter, normalizePath } from 'obsidian';
+
+export interface CachedEntry {
+    path: string;
+    type: 'file' | 'folder';
+    mtime?: number;
+    size?: number;
+}
+
+export interface MountScanCache {
+    mountId: string;
+    virtualPath: string;
+    savedAt: number;
+    entries: CachedEntry[];
+}
+
+export interface ScanCacheFile {
+    version: 1;
+    mounts: MountScanCache[];
+}
+
+export interface ReplayCacheDeps {
+    hasAbstractFile(path: string): boolean;
+    onFolderCreated(path: string): Promise<void>;
+    onFileCreated(path: string, stat: null): Promise<void>;
+}
+
+export function isCacheFresh(mountCache: MountScanCache, maxAgeMs: number): boolean {
+    return Date.now() - mountCache.savedAt < maxAgeMs;
+}
+
+export async function loadScanCache(
+    adapter: DataAdapter,
+    cachePath: string,
+): Promise<ScanCacheFile | null> {
+    try {
+        const raw = await adapter.read(cachePath);
+        const parsed = JSON.parse(raw) as unknown;
+        if (
+            typeof parsed === 'object' &&
+            parsed !== null &&
+            (parsed as ScanCacheFile).version === 1 &&
+            Array.isArray((parsed as ScanCacheFile).mounts)
+        ) {
+            return parsed as ScanCacheFile;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+export async function saveScanCache(
+    adapter: DataAdapter,
+    cachePath: string,
+    cache: ScanCacheFile,
+): Promise<void> {
+    await adapter.write(cachePath, JSON.stringify(cache));
+}
+
+/**
+ * Replay a mount's cached entries into the vault without hitting the filesystem.
+ * Entries already known to the vault (hasAbstractFile) are skipped, so replaying
+ * a stale cache is safe — the background scan will correct any phantom entries.
+ */
+export async function replayCacheToVault(
+    mountCache: MountScanCache,
+    deps: ReplayCacheDeps,
+): Promise<void> {
+    // Folders must be created before their children, so process in original order
+    // (the cache is written in depth-first order by replayMountContentsToVault).
+    let yieldCounter = 0;
+    for (const entry of mountCache.entries) {
+        const path = normalizePath(entry.path);
+        if (deps.hasAbstractFile(path)) continue;
+
+        if (entry.type === 'folder') {
+            await deps.onFolderCreated(path);
+        } else {
+            await deps.onFileCreated(path, null);
+        }
+
+        // Yield to event loop every 100 entries to keep UI responsive
+        yieldCounter++;
+        if (yieldCounter % 100 === 0) {
+            await new Promise<void>(resolve => setTimeout(resolve, 0));
+        }
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,15 @@ export interface MountPoint {
 	id: string;            // Unique identifier (generated at creation)
 	virtualPath: string;   // Normalized vault path, e.g. "Projects/Work"
 	realPath: string;      // Absolute OS path (local/vault) OR server-relative path (webdav/sftp) OR S3 prefix (s3)
+	/**
+	 * Alternative path tried automatically when realPath is not accessible.
+	 * Useful for cross-platform vaults: set the Windows path as realPath and the
+	 * Linux/macOS path here (or vice-versa).  The fallback is tried once at mount
+	 * activation; if accessible it is used transparently for all I/O.
+	 * A configured fallback also enables the mount on foreign devices without
+	 * requiring allowForeignMounts.
+	 */
+	fallbackRealPath?: string;
 	enabled: boolean;      // Whether the mount is currently active
 	readOnly: boolean;     // Block all write operations through this mount
 	label?: string;        // Optional human-readable display name
@@ -113,6 +122,12 @@ export interface FolderBridgeSettings {
 	mountPoints: MountPoint[];
 	allowlist: string[];    // Approved real paths (must match before any I/O)
 	managedTocSource: string; // Optional writable TOC file for UI-managed local/vault mounts
+	/**
+	 * Alternative TOC file path tried when managedTocSource is not accessible.
+	 * Useful for cross-platform vaults: set the Windows path as managedTocSource
+	 * and the Linux/macOS path here (or vice-versa).
+	 */
+	managedTocSourceFallback?: string;
 	tocSources: string[];   // Absolute paths to JSON config files that define additional mounts
 	dryRun: boolean;        // Log writes without executing them
 	showStatusBar: boolean;
@@ -134,6 +149,7 @@ export const DEFAULT_SETTINGS: FolderBridgeSettings = {
 	mountPoints: [],
 	allowlist: [],
 	managedTocSource: '',
+	managedTocSourceFallback: undefined,
 	tocSources: [],
 	dryRun: false,
 	showStatusBar: true,
@@ -157,6 +173,7 @@ export interface TocFileMount {
 	deviceId?: string;
 	virtualPath: string;
 	realPath: string;
+	fallbackRealPath?: string;
 	label?: string;
 	enabled?: boolean;
 	readOnly?: boolean;

--- a/src/ui/MountManagerModal.ts
+++ b/src/ui/MountManagerModal.ts
@@ -179,6 +179,7 @@ export class MountManagerModal extends Modal {
 	private mountType: MountType = 'local';
 	private virtualPath = '';
 	private realPath = '';
+	private fallbackRealPath = '';
 	private readOnly = false;
 	private label = '';
 	private useFolderNameAsLabel = false;
@@ -233,6 +234,7 @@ export class MountManagerModal extends Modal {
 			this.mountType = editMount.mountType ?? 'local';
 			this.virtualPath = editMount.virtualPath;
 			this.realPath = editMount.realPath;
+			this.fallbackRealPath = editMount.fallbackRealPath ?? '';
 			this.readOnly = editMount.readOnly;
 			this.label = editMount.label ?? '';
 			// WebDAV
@@ -760,6 +762,41 @@ export class MountManagerModal extends Modal {
 			});
 		}
 
+		// ── Fallback path ──────────────────────────────────────────────────
+		// Only meaningful for local/vault mounts; cloud adapters resolve their own paths.
+		let fallbackPathText: import('obsidian').TextComponent | null = null;
+		new Setting(localSection)
+			.setName('Fallback path (optional)')
+			.setDesc(
+				'Alternative folder tried automatically if the real path above is not ' +
+				'accessible on this machine. Useful for cross-platform vaults: set ' +
+				'the Windows path above and the Linux/macOS path here (or vice-versa). ' +
+				'A mount with a fallback configured activates on any device without ' +
+				'extra per-device setup.'
+			)
+			.addText(text => {
+				fallbackPathText = text;
+				text.inputEl.addClass('folderbridge-input-flex');
+				text.inputEl.style.minWidth = '200px';
+				text.setPlaceholder('/home/yourname/Documents/Work  or  C:\\Users\\You\\Documents\\Work')
+					.setValue(this.fallbackRealPath)
+					.onChange(val => { this.fallbackRealPath = val.trim(); });
+			})
+			.addButton(btn => {
+				btn.setButtonText('Browse…')
+					.setTooltip('Open the system folder picker')
+					.onClick(() => {
+						void (async () => {
+							const selected = await browseFolderOnDisk('Select fallback folder');
+							if (selected) {
+								this.fallbackRealPath = selected;
+								fallbackPathText?.setValue(selected);
+							}
+						})();
+					});
+				btn.buttonEl.setAttribute('aria-label', 'Browse for fallback folder on disk');
+			});
+
 		// ── Virtual path ───────────────────────────────────────────────────
 		new Setting(contentEl)
 			.setName('Virtual path (in vault)')
@@ -1206,13 +1243,6 @@ export class MountManagerModal extends Modal {
 			new Notice(`${this.pluginName}: Real path is required.`);
 			return;
 		}
-		if (!path.isAbsolute(this.realPath)) {
-			this.submitState.finish();
-			this.syncSubmitButtons();
-			new Notice(`${this.pluginName}: Real path must be an absolute filesystem path.`);
-			return;
-		}
-
 		const normalizedVirtual = normalizePath(virtualPathToUse);
 
 		// Validate via SecurityManager (dangerous paths, duplicate mounts, etc.)
@@ -1233,9 +1263,20 @@ export class MountManagerModal extends Modal {
 			return;
 		}
 
-		// Only re-check accessibility when the real path has changed (or this is a new mount)
+		// Only re-check absoluteness and accessibility when the real path has changed (or this is a new mount).
+		// Skipping these checks on unchanged paths allows cross-platform editing — e.g. a Windows path saved
+		// on Windows can be edited on Linux to add a fallback without failing path.isAbsolute() on Linux.
 		const realPathChanged = !this.editMount || this.editMount.realPath !== this.realPath;
 		if (realPathChanged) {
+			// Accept paths that are absolute on either platform (e.g. /home/... on Linux, C:\... on Windows)
+			const isAbsolute = path.posix.isAbsolute(this.realPath) || path.win32.isAbsolute(this.realPath);
+			if (!isAbsolute) {
+				this.submitState.finish();
+				this.syncSubmitButtons();
+				new Notice(`${this.pluginName}: Real path must be an absolute filesystem path.`);
+				return;
+			}
+
 			const dirExists = await isDirectory(this.realPath);
 			if (!dirExists) {
 				this.submitState.finish();
@@ -1263,6 +1304,7 @@ export class MountManagerModal extends Modal {
 			{
 				virtualPath: normalizedVirtual,
 				realPath: this.realPath,
+				fallbackRealPath: this.fallbackRealPath || undefined,
 				enabled: this.editMount ? this.editMount.enabled : true,
 				readOnly: this.readOnly,
 				label: this.label || undefined,


### PR DESCRIPTION
**Problem:** Vaults synced between Windows and Linux/macOS fail to mount because data.json stores Windows paths (D:\...) which are invalid on other platforms. There was no way to remap paths per-device without manually editing settings on each machine.

**Solution:** Adds an optional fallbackRealPath per mount. If the primary path is inaccessible at load time, the plugin automatically tries the fallback — silently, with no user intervention required after initial setup. Also adds the same fallback for the managed TOC file path.

**Changes:**

- New fallbackRealPath field on MountPoint and TocFileMount
- New managedTocSourceFallback setting
- PathMapper: runtime fallback resolution cache (never persisted)
- SecurityManager: cross-platform absolute path check (posix + win32) — bug fix that also prevents false "not absolute" errors on Linux for unchanged Windows paths
- MountManagerModal: fallback path field + Browse button
- TocConfig: serialize/parse fallbackRealPath in TOC JSON
- Zero breaking changes — all new fields are optional

New Fallback for TOC to Linux Location
<img width="1001" height="597" alt="image" src="https://github.com/user-attachments/assets/a08824a7-bece-4d9c-a3cf-7ee6b635b55c" />

New Fallback for Individual Mounts so doesn't break on Linux > PC setups across devices
<img width="766" height="678" alt="image" src="https://github.com/user-attachments/assets/7048340a-18f0-4951-b63a-6418ce2ccbdc" />
