### PR TITLE
Fix issues with hidden files not showing or refreshing properly in mounts

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -53,7 +53,7 @@ const optionalNodeModulesPlugin = {
 	name: 'optional-node-modules',
 	setup(build) {
 		build.onResolve({ filter: /^\.\/optionalNodeModules$/ }, args => {
-			if (!args.importer.endsWith('/src/runtimeNode.ts')) {
+			if (!args.importer.replace(/\\/g, '/').endsWith('/src/runtimeNode.ts')) {
 				return null;
 			}
 

--- a/main.ts
+++ b/main.ts
@@ -434,7 +434,7 @@ export default class FolderBridgePlugin extends Plugin {
 		this.pathMapper.update(this.settings.mountPoints, this.settings.deviceId);
 
 		// [FEATURE_20260222] Initialize FileWatcher
-		this.fileWatcher = new FileWatcher(this.app, this.pathMapper, (name, mount) => this.isNameIgnored(name, mount));
+		this.fileWatcher = new FileWatcher(this.app, this.pathMapper, (name, mount, mountRelativePath) => this.isNameIgnored(name, mount, mountRelativePath));
 
 		// Install the virtual adapter shim
 		this.installVirtualAdapter();

--- a/src/FileWatcher.ts
+++ b/src/FileWatcher.ts
@@ -143,9 +143,7 @@ export class FileWatcher {
         // [FEATURE_20260222] Initialize chokidar watcher for the mount's real path
         const watcher = chokidar.watch(realPath, {
             ignored: (testPath: string, stats?: import('fs').Stats) => {
-                // Ignore hidden files/folders and node_modules
                 const name = path.basename(testPath);
-                if (name.startsWith('.') || name === 'node_modules') return true;
 
                 // Compute mount-relative real path for path-style ignore patterns
                 const normalizedTest = testPath.replace(/\\/g, '/');

--- a/src/mountScan.ts
+++ b/src/mountScan.ts
@@ -66,7 +66,6 @@ export async function replayMountContentsToVault(
                     : undefined;
 
                 if (deps.isIgnored(folderName, mount, folderMountRelPath)) continue;
-                if (folderName.startsWith('.') || folderName === 'node_modules') continue;
 
                 if (!deps.hasAbstractFile(folder)) {
                     await deps.onFolderCreated(folder);
@@ -95,7 +94,6 @@ export async function replayMountContentsToVault(
                     : undefined;
 
                 if (deps.isIgnored(fileName, mount, fileMountRelPath)) continue;
-                if (fileName.startsWith('.')) continue;
                 if (!isVisibleFileInMount(file, mount)) continue;
 
                 if (!deps.hasAbstractFile(file)) {

--- a/tests/FileWatcher.test.ts
+++ b/tests/FileWatcher.test.ts
@@ -196,15 +196,30 @@ describe('FileWatcher', () => {
             return options.ignored;
         }
 
-        it('ignores hidden files (name starts with .)', () => {
-            const ignored = getIgnored();
+        function getIgnoredWithPatterns(isIgnored: (name: string, m: MountPoint, rel?: string) => boolean): (p: string) => boolean {
+            const { app } = makeApp();
+            const fw = new FileWatcher(app, makeMapper(mount), isIgnored);
+            fw.startWatching(mount);
+            const options = getWatchOptions();
+            if (!options.ignored) throw new Error('Expected ignored callback to be registered');
+            return options.ignored;
+        }
+
+        it('delegates dot-file filtering to isIgnored callback', () => {
+            const ignored = getIgnoredWithPatterns((name) => name === '.git' || name === '.DS_Store');
             expect(ignored('C:/Users/test/Documents/.git')).toBe(true);
             expect(ignored('C:/Users/test/Documents/.DS_Store')).toBe(true);
         });
 
-        it('ignores node_modules', () => {
-            const ignored = getIgnored();
+        it('delegates node_modules filtering to isIgnored callback', () => {
+            const ignored = getIgnoredWithPatterns((name) => name === 'node_modules');
             expect(ignored('C:/Users/test/Documents/node_modules')).toBe(true);
+        });
+
+        it('does not ignore dot-files when isIgnored returns false', () => {
+            const ignored = getIgnored();
+            expect(ignored('C:/Users/test/Documents/.env')).toBe(false);
+            expect(ignored('C:/Users/test/Documents/.obsidian_link')).toBe(false);
         });
 
         it('does not ignore regular files', () => {


### PR DESCRIPTION
## Description
Fix issues with hidden files not showing or refreshing properly in mounts.  This made including .folders like `~\.claude` or `~\.agents` etc. with agent and skill md files in vaults particularly problematic.

The main issue was leftover hard-coded blocks on .files and .folders from before ignore lists were implemented.   Main code edits done by Claude Opus.  See attached [research.md](https://github.com/user-attachments/files/26754290/research.md) file for detailed change info and reasoning.

## Related Issues
Fixes #26 

## Changes Made
- remove hardcoded .file blocks, those are handled by ignore lists now as they are not needed

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Code refactoring
- [x] Other (please describe): fixed one additional leftover issue in file watcher logic

## Testing Performed
<!-- Describe the tests you ran and their results -->
- [x] Built successfully with `npm run build`
- [x] No TypeScript errors
- [x] No ESLint warnings
- [x] Tested in Obsidian
- [ ] Tested on multiple platforms (if applicable): 
  - N/A no others available

### Test Environment
- **OS**: Win11
- **Obsidian Version**: 1.12.7
- **Node.js Version**: 24.14.1

## Screenshots
<img width="952" height="745" alt="image" src="https://github.com/user-attachments/assets/0af85558-f7e1-4489-8e71-00c1e6f9ca91" />

## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly

## Additional Notes

See [research.md](https://github.com/user-attachments/files/26754290/research.md)


