### PR TITLE
Fix macOS arm64 install/build: remove linux-only esbuild dep and tighten TS typing

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1064,7 +1064,7 @@ export default class FolderBridgePlugin extends Plugin {
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 				return orig ? Object.getPrototypeOf(orig) : Object.getPrototypeOf(target);
 			},
-		}) as DataAdapter;
+		}) as unknown as DataAdapter;
 
 		// Obsidian's renderer calls Vault.getResourcePath(TFile) directly — it does NOT
 		// go through the adapter. We must also patch the vault-level method so that
@@ -2637,9 +2637,12 @@ class FolderBridgeSettingTab extends PluginSettingTab {
 							try {
 								const text = await file.text();
 								const parsed = JSON.parse(text) as unknown;
-								const mounts: MountPoint[] = Array.isArray(parsed)
-									? (parsed as MountPoint[])                        // legacy bare array
-									: (parsed as Record<string, unknown>).mountPoints ?? [];    // { version, mountPoints }
+								const rawMounts: unknown = Array.isArray(parsed)
+									? parsed // legacy bare array
+									: (parsed as Record<string, unknown>).mountPoints; // { version, mountPoints }
+								const mounts: MountPoint[] = Array.isArray(rawMounts)
+									? (rawMounts as MountPoint[])
+									: [];
 								if (!Array.isArray(mounts) || mounts.length === 0) {
 									new Notice(`${this.plugin.manifest.name}: no mount points found in the selected file.`);
 									return;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "author": "tescolopio",
     "license": "MIT",
     "devDependencies": {
-        "@esbuild/linux-x64": "^0.27.3",
         "@eslint/json": "^1.1.0",
         "@types/node": "^20.11.16",
         "@types/ssh2": "^1.15.4",

--- a/src/CredentialStore.ts
+++ b/src/CredentialStore.ts
@@ -39,16 +39,18 @@ type SafeStorage = {
     decryptString(encrypted: Buffer): string;
 };
 
+type ElectronWithSafeStorage = {
+    remote?: { safeStorage?: SafeStorage };
+    safeStorage?: SafeStorage;
+};
+
 function getSafeStorage(): SafeStorage | null {
     try {
         const runtimeRequire = getRuntimeRequire();
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const electron = runtimeRequire?.('electron');
+        const electron = runtimeRequire?.('electron') as ElectronWithSafeStorage | undefined;
         // safeStorage lives in the main process; Obsidian re-exports it via remote.
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const ss: SafeStorage | undefined =
-            (electron as Record<string, unknown>)?.remote?.safeStorage ??
-            (electron as Record<string, unknown>)?.safeStorage;
+        const ss: SafeStorage | undefined = electron?.remote?.safeStorage ?? electron?.safeStorage;
         return ss ?? null;
     } catch {
         return null;

--- a/src/ui/MountManagerModal.ts
+++ b/src/ui/MountManagerModal.ts
@@ -21,6 +21,11 @@ interface ElectronOpenDialogOptions {
 	defaultPath?: string;
 }
 
+type ElectronWithDialog = {
+	remote?: { dialog?: ElectronDialog };
+	dialog?: ElectronDialog;
+};
+
 // ---------------------------------------------------------------------------
 // Electron folder-picker helper
 // ---------------------------------------------------------------------------
@@ -34,11 +39,11 @@ export async function browseFolderOnDisk(title = 'Select folder', defaultPath?: 
 	try {
 		const runtimeRequire = getRuntimeRequire();
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-		const electron = runtimeRequire?.('electron');
+		const electron = runtimeRequire?.('electron') as ElectronWithDialog | undefined;
 		// Electron ≥ 14 ships remote via @electron/remote; Obsidian re-exports
 		// it on the electron object so both old and new versions work here.
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-		const dialog: ElectronDialog | undefined = (electron as Record<string, unknown>)?.remote?.dialog ?? (electron as Record<string, unknown>)?.dialog;
+		const dialog: ElectronDialog | undefined = electron?.remote?.dialog ?? electron?.dialog;
 		if (!dialog?.showOpenDialog) {
 			new Notice('Native folder browser is unavailable. Please type the path manually.');
 			return null;
@@ -69,9 +74,9 @@ export async function browseMultipleFoldersOnDisk(title = 'Select folders', defa
 	try {
 		const runtimeRequire = getRuntimeRequire();
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-		const electron = runtimeRequire?.('electron');
+		const electron = runtimeRequire?.('electron') as ElectronWithDialog | undefined;
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-		const dialog: ElectronDialog | undefined = (electron as Record<string, unknown>)?.remote?.dialog ?? (electron as Record<string, unknown>)?.dialog;
+		const dialog: ElectronDialog | undefined = electron?.remote?.dialog ?? electron?.dialog;
 		if (!dialog?.showOpenDialog) {
 			new Notice('Native folder browser is unavailable. Please type the path manually.');
 			return null;


### PR DESCRIPTION
## Summary
Fixes source install/build on macOS Apple Silicon (`darwin arm64`).
## Changes
- `package.json`
  - removed linux-only `@esbuild/linux-x64` from `devDependencies`
- `main.ts`
  - proxy cast adjusted to `as unknown as DataAdapter`
  - import parsing now validates `mountPoints` array before casting
- `src/CredentialStore.ts`
  - typed Electron safeStorage access (`remote?.safeStorage` / `safeStorage`)
- `src/ui/MountManagerModal.ts`
  - typed Electron dialog access (`remote?.dialog` / `dialog`)
## Why
`@esbuild/linux-x64` in devDependencies causes `npm install` to fail on non-Linux hosts (`EBADPLATFORM`).
After install was fixed, TypeScript reported strict typing errors in the files above.
## Validation
On macOS arm64:
- `npm install` ✅
- `npm run build` ✅
- plugin loaded successfully in Obsidian ✅
- successfully mounted a local folder (`newbeans/docs`) ✅
- mount enable/disable/remove actions worked correctly ✅
