### PR TITLE
Fix: allowlist paths with trailing separators reject all child files

### DIFF
--- a/src/OSHelpers.ts
+++ b/src/OSHelpers.ts
@@ -312,6 +312,15 @@ export function tryReadAsDataUri(realPath: string, maxBytes = MAX_SYNC_DATA_URI_
  */
 export function normalizeForComparison(p: string): string {
 	let n = path.normalize(p);
+	// path.normalize preserves trailing separators.  Strip them so that
+	// prefix comparisons in SecurityManager.isAllowed() don't produce a
+	// double-separator (e.g. "C:\path\" + "\" → "C:\path\\") that never
+	// matches child paths.  Preserve the separator for filesystem roots
+	// like "C:\" or "/" where it is semantically significant.
+	const root = path.parse(n).root;
+	if (n !== root && (n.endsWith('/') || n.endsWith('\\'))) {
+		n = n.slice(0, -1);
+	}
 	if (getPlatform() !== 'windows' && path.sep === '\\') {
 		n = n.replace(/\\/g, '/');
 	}

--- a/tests/OSHelpers.test.ts
+++ b/tests/OSHelpers.test.ts
@@ -63,6 +63,27 @@ describe('OSHelpers', () => {
 				expect(result).toBe(result.toLowerCase());
 			});
 		});
+
+		it('strips trailing backslash on Windows', () => {
+			withPlatform('win32', () => {
+				const result = normalizeForComparison('C:\\foo\\bar\\');
+				expect(result).toBe('c:\\foo\\bar');
+			});
+		});
+
+		it('strips trailing forward slash on POSIX', () => {
+			withPlatform('linux', () => {
+				expect(normalizeForComparison('/foo/bar/')).toBe('/foo/bar');
+			});
+		});
+
+		it('preserves trailing separator for filesystem root', () => {
+			withPlatform('win32', () => {
+				// "C:\" is a root — trailing sep must stay
+				const result = normalizeForComparison('C:\\');
+				expect(result).toBe('c:\\');
+			});
+		});
 	});
 
 	describe('isUNCPath', () => {

--- a/tests/SecurityManager.test.ts
+++ b/tests/SecurityManager.test.ts
@@ -40,6 +40,16 @@ describe('SecurityManager', () => {
 			// /allowed/pathmore should NOT be allowed when /allowed/path is in list
 			expect(sec.isAllowed('/allowed/pathmore')).toBe(false);
 		});
+
+		it('allows child paths when allowlisted path has a trailing separator', () => {
+			// Regression: path.normalize preserves trailing separators.
+			// If the allowlist entry has a trailing "\", isAllowed must still
+			// match child paths.
+			const secTrailing = new SecurityManager(['C:\\foo\\bar\\']);
+			expect(secTrailing.isAllowed('C:\\foo\\bar\\README.md')).toBe(true);
+			expect(secTrailing.isAllowed('C:\\foo\\bar\\sub\\file.txt')).toBe(true);
+			expect(secTrailing.isAllowed('C:\\foo\\bar')).toBe(true);
+		});
 	});
 
 	describe('allow / revoke', () => {


### PR DESCRIPTION
## Description
When `data.json` contains an allowlist entry with a trailing separator (e.g. `"C:\repos\Project\"`), every `read`/`write`/`append` call on files inside that mount throws:

> `"C:\repos\Project\README.md" is not on the allowlist. Add the mount in plugin settings to permit access.`

The mount still appears in the file explorer because `list()` and `stat()` don't call `assertAllowed()`, but clicking any file fails.

## Root cause

`path.normalize()` preserves trailing separators per the Node.js spec. `SecurityManager.isAllowed()` then builds prefix checks like:

```
"c:\repos\project\readme.md".startsWith("c:\repos\project\" + "\")
//                                        → "c:\repos\project\\" — double separator, never matches
```


## Related Issues
Fixes: #29

## Changes Made
- fix code to transparently handle with or without trailing spaces (with exception for root such as `/` on linux or `c:\` on Windows.

## Type of Change
<!-- Check all that apply -->
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing Performed
- [x] Built successfully with `npm run build`
- [x] No TypeScript errors
- [x] No ESLint warnings
- [x] Tested in Obsidian
- [x] Tested on multiple platforms (if applicable): N/A (Windows only)

### Test Environment
OS: Win11
Obsidian Version:
Plugin Version: 2.15.3
Node.js Versionif development): 24.14.1

## Screenshots
See #29 

## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly
