### PR TITLE
Add file explorer mount metadata and folder mount action

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -104,6 +104,10 @@ export default class FolderBridgePlugin extends Plugin {
 	// Preserve original app.openWithDefaultApp so we can restore it on unload
 	private originalOpenWithDefaultApp: unknown = null;
 	statusBarItem: HTMLElement | null = null;
+	explorerObserver: MutationObserver | null = null;
+	private explorerTooltipRoots = new WeakSet<HTMLElement>();
+	private nativeTooltipObserver: MutationObserver | null = null;
+	private activeExplorerMountTooltipText: string | null = null;
 
 	/** Tracks reachability per mount.id; populated by the 30-second health-check loop. */
 	mountHealthMap = new Map<string, boolean>();
@@ -770,6 +774,9 @@ export default class FolderBridgePlugin extends Plugin {
 					}
 				}
 
+				// Highlight mounted folders in the file explorer
+				this.setupExplorerHighlighting();
+
 				for (const mount of activeMounts) {
 					await this.notifyVaultMountAdded(mount);
 				}
@@ -798,6 +805,9 @@ export default class FolderBridgePlugin extends Plugin {
 	}
 
 	onunload() {
+		// Stop the file-explorer highlighting observer
+		this.teardownExplorerHighlighting();
+		this.teardownNativeTooltipObserver();
 		// Stop background health-check loop before watcher so no stale notices fire
 		if (this.healthCheckInterval !== null) {
 			clearInterval(this.healthCheckInterval);
@@ -843,6 +853,362 @@ export default class FolderBridgePlugin extends Plugin {
 	// ------------------------------------------------------------------
 	// Helpers
 	// ------------------------------------------------------------------
+
+	/**
+	 * Set up a MutationObserver on the file-explorer DOM to add visual
+	 * indicators (CSS classes) to mounted folders in the tree.
+	 *
+	 * Tooltip: the file explorer renders its file-count tooltip internally, so
+	 * mount details are merged into the already-open tooltip during hover.
+	 */
+	private setupExplorerHighlighting(): void {
+		this.teardownExplorerHighlighting();
+
+		const apply = () => this.highlightMountedInExplorer();
+
+		const tryObserve = () => {
+			const leaves = this.app.workspace.getLeavesOfType('file-explorer');
+			if (!leaves.length) return;
+			const explorerEl = leaves[0].view.containerEl;
+			this.registerExplorerTooltipAugmentation(explorerEl);
+			this.setupNativeTooltipObserver();
+
+			if (this.explorerObserver) {
+				apply();
+				return;
+			}
+
+			this.explorerObserver = new MutationObserver(() => apply());
+			this.explorerObserver.observe(explorerEl, { childList: true, subtree: true });
+			apply();
+		};
+
+		// Initial attempt
+		tryObserve();
+
+		// Re-attach when the file explorer is opened/closed
+		this.registerEvent(this.app.workspace.on('layout-change', () => {
+			// If the observer was lost (file explorer was closed), clean up
+			if (this.explorerObserver) {
+				// Check if the observed element is still in the DOM
+				const leaves = this.app.workspace.getLeavesOfType('file-explorer');
+				const stillAlive = leaves.length > 0 &&
+					document.contains(leaves[0].view.containerEl);
+				if (!stillAlive) {
+					this.explorerObserver.disconnect();
+					this.explorerObserver = null;
+				}
+			}
+			tryObserve();
+		}));
+	}
+
+	private teardownExplorerHighlighting(): void {
+		if (this.explorerObserver) {
+			this.explorerObserver.disconnect();
+			this.explorerObserver = null;
+		}
+	}
+
+	private setupNativeTooltipObserver(): void {
+		if (this.nativeTooltipObserver || !document.body) return;
+
+		this.nativeTooltipObserver = new MutationObserver(() => {
+			if (this.activeExplorerMountTooltipText) {
+				this.appendMountInfoToNativeTooltip(this.activeExplorerMountTooltipText);
+			} else {
+				this.removeMountInfoFromNativeTooltips();
+			}
+		});
+		this.nativeTooltipObserver.observe(document.body, { childList: true, subtree: true });
+	}
+
+	private teardownNativeTooltipObserver(): void {
+		if (this.nativeTooltipObserver) {
+			this.nativeTooltipObserver.disconnect();
+			this.nativeTooltipObserver = null;
+		}
+		this.activeExplorerMountTooltipText = null;
+	}
+
+	private registerExplorerTooltipAugmentation(explorerEl: HTMLElement): void {
+		if (this.explorerTooltipRoots.has(explorerEl)) return;
+		this.explorerTooltipRoots.add(explorerEl);
+
+		this.registerDomEvent(explorerEl, 'mouseover', (event: MouseEvent) => {
+			const target = event.target;
+			if (!(target instanceof HTMLElement)) return;
+
+			const titleEl = target.closest<HTMLElement>('.nav-folder-title, .nav-file-title');
+			if (!titleEl || !explorerEl.contains(titleEl)) return;
+
+			const folderTitleEl = titleEl.matches('.nav-folder-title.folderbridge-mounted')
+				? titleEl
+				: null;
+			if (!folderTitleEl) {
+				this.activeExplorerMountTooltipText = null;
+				this.removeMountInfoFromNativeTooltips();
+				return;
+			}
+
+			this.scheduleNativeTooltipAugmentation(folderTitleEl);
+		}, true);
+
+		this.registerDomEvent(explorerEl, 'mouseout', (event: MouseEvent) => {
+			const target = event.target;
+			if (!(target instanceof HTMLElement)) return;
+
+			const folderTitleEl = target.closest<HTMLElement>('.nav-folder-title.folderbridge-mounted');
+			if (!folderTitleEl || !explorerEl.contains(folderTitleEl)) return;
+
+			const relatedTarget = event.relatedTarget;
+			if (relatedTarget instanceof Node && folderTitleEl.contains(relatedTarget)) return;
+
+			this.activeExplorerMountTooltipText = null;
+			this.removeMountInfoFromNativeTooltips();
+		}, true);
+	}
+
+	private scheduleNativeTooltipAugmentation(folderTitleEl: HTMLElement): void {
+		const tooltipText = folderTitleEl.dataset.folderbridgeMountTooltip;
+		if (!tooltipText) return;
+		this.activeExplorerMountTooltipText = tooltipText;
+
+		const apply = () => this.appendMountInfoToNativeTooltip(tooltipText);
+		window.requestAnimationFrame(apply);
+		window.setTimeout(apply, 50);
+		window.setTimeout(apply, 150);
+		window.setTimeout(apply, 300);
+		window.setTimeout(apply, 600);
+	}
+
+	private appendMountInfoToNativeTooltip(tooltipText: string): void {
+		const tooltipEl = Array.from(document.querySelectorAll<HTMLElement>('.tooltip, [class~="tooltip"]'))
+			.reverse()
+			.find(el => {
+				const rect = el.getBoundingClientRect();
+				return rect.width > 0 && rect.height > 0;
+			});
+		if (!tooltipEl) return;
+
+		const contentEl = this.findNativeTooltipContentEl(tooltipEl);
+		const existingAugmented = tooltipEl.querySelector<HTMLElement>('.folderbridge-tooltip-augmented');
+		if (existingAugmented?.dataset.folderbridgeText === tooltipText) return;
+
+		const originalText = this.stripExplorerMountTooltipText(
+			existingAugmented?.dataset.folderbridgeOriginalText ?? contentEl.textContent?.trim() ?? ''
+		);
+		tooltipEl.addClass('folderbridge-tooltip-container-augmented');
+		const tooltipStyle = window.getComputedStyle(tooltipEl);
+		const tooltipBackgroundColor = this.getVisibleBackgroundColor(tooltipEl);
+		if (tooltipBackgroundColor) {
+			tooltipEl.style.backgroundColor = tooltipBackgroundColor;
+		}
+		tooltipEl.style.color = tooltipStyle.color;
+
+		contentEl.querySelectorAll<HTMLElement>('.folderbridge-tooltip-augmented').forEach(el => el.remove());
+		Array.from(contentEl.childNodes).forEach(node => {
+			if (node.nodeType === Node.TEXT_NODE && node.textContent?.trim()) {
+				node.remove();
+			}
+		});
+
+		const augmentedEl = document.createElement('div');
+		augmentedEl.className = 'folderbridge-tooltip-augmented';
+		augmentedEl.dataset.folderbridgeOriginalText = originalText;
+		augmentedEl.dataset.folderbridgeText = tooltipText;
+
+		for (const line of [originalText, ...tooltipText.split('\n')].filter(Boolean)) {
+			const lineEl = document.createElement('div');
+			lineEl.className = 'folderbridge-tooltip-line';
+			lineEl.textContent = line;
+			augmentedEl.appendChild(lineEl);
+		}
+		contentEl.appendChild(augmentedEl);
+	}
+
+	private findNativeTooltipContentEl(tooltipEl: HTMLElement): HTMLElement {
+		const existingAugmented = tooltipEl.querySelector<HTMLElement>('.folderbridge-tooltip-augmented');
+		if (existingAugmented?.parentElement instanceof HTMLElement) return existingAugmented.parentElement;
+
+		const candidates = [
+			...Array.from(tooltipEl.querySelectorAll<HTMLElement>('*')),
+			tooltipEl,
+		];
+
+		const visibleTextCandidates = candidates.filter(el => {
+			if (el.classList.contains('folderbridge-tooltip-augmented')) return true;
+			if (el.className.toString().includes('arrow')) return false;
+			const rect = el.getBoundingClientRect();
+			return rect.width > 0 && rect.height > 0 && !!el.textContent?.trim();
+		});
+
+		const leafTextEl = visibleTextCandidates.find(el =>
+			!Array.from(el.children).some(child => child.textContent?.trim() === el.textContent?.trim())
+		);
+		if (leafTextEl) return leafTextEl;
+
+		return tooltipEl.querySelector<HTMLElement>('.tooltip-content') ?? tooltipEl;
+	}
+
+	private stripExplorerMountTooltipText(text: string): string {
+		const markerIndices = ['Mount:', 'Path:']
+			.map(marker => text.indexOf(marker))
+			.filter(index => index >= 0);
+		const firstMarkerIndex = markerIndices.length > 0 ? Math.min(...markerIndices) : -1;
+		const baseText = firstMarkerIndex >= 0 ? text.slice(0, firstMarkerIndex) : text;
+		return baseText
+			.split('\n')
+			.map(line => line.trim())
+			.filter(line => line && !line.startsWith('Mount:') && !line.startsWith('Path:'))
+			.join(' ');
+	}
+
+	private getVisibleBackgroundColor(el: HTMLElement): string | null {
+		const candidates = [
+			el,
+			...Array.from(el.querySelectorAll<HTMLElement>('*')),
+		];
+
+		for (const candidate of candidates) {
+			const backgroundColor = window.getComputedStyle(candidate).backgroundColor;
+			if (
+				backgroundColor &&
+				backgroundColor !== 'transparent' &&
+				!backgroundColor.endsWith(', 0)') &&
+				backgroundColor !== 'rgba(0, 0, 0, 0)'
+			) {
+				return backgroundColor;
+			}
+		}
+
+		return null;
+	}
+
+	private removeMountInfoFromNativeTooltips(): void {
+		document.querySelectorAll<HTMLElement>('.folderbridge-tooltip-container-augmented').forEach(el => {
+			el.removeClass('folderbridge-tooltip-container-augmented');
+			el.style.removeProperty('background-color');
+			el.style.removeProperty('color');
+		});
+		document.querySelectorAll<HTMLElement>('.folderbridge-tooltip-augmented').forEach(el => {
+			const originalText = el.dataset.folderbridgeOriginalText;
+			if (originalText !== undefined) {
+				el.replaceWith(document.createTextNode(originalText));
+			} else {
+				el.remove();
+			}
+		});
+	}
+
+	private clearTooltipAttributes(el: HTMLElement, mount?: MountPoint, typeLabel?: string): void {
+		const mountText = mount ? [
+			mount.realPath,
+			typeLabel ?? '',
+			mount.label ?? '',
+			'FolderBridge',
+		].filter(Boolean) : ['FolderBridge'];
+
+		const elements = [el, ...Array.from(el.querySelectorAll<HTMLElement>('[title], [aria-label]'))];
+		for (const item of elements) {
+			item.removeAttribute('title');
+
+			const ariaLabel = item.getAttribute('aria-label');
+			if (ariaLabel && mountText.some(text => ariaLabel.includes(text))) {
+				item.removeAttribute('aria-label');
+			}
+		}
+	}
+
+	private setExplorerMountMetadata(el: HTMLElement, mount: MountPoint, typeLabel: string): void {
+		this.clearTooltipAttributes(el, mount, typeLabel);
+
+		const label = mount.label ? ` (${mount.label})` : '';
+		el.dataset.folderbridgeMountTooltip = [
+			`Mount: ${typeLabel}${label}`,
+			`Path: ${mount.realPath}`,
+		].join('\n');
+	}
+
+	private clearExplorerMountMetadata(el: HTMLElement): void {
+		this.clearTooltipAttributes(el);
+		delete el.dataset.folderbridgeMountTooltip;
+	}
+
+	/**
+	 * Walk the file-explorer DOM and add CSS classes to tree items whose
+	 * path belongs to a mount point.  Also sets a tooltip with mount source
+	 * details on the root folder of each mount.
+	 */
+	private highlightMountedInExplorer(): void {
+		const leaves = this.app.workspace.getLeavesOfType('file-explorer');
+		if (!leaves.length) return;
+
+		const explorerEl = leaves[0].view.containerEl;
+
+		// Collect mount paths for fast lookup
+		const activeMounts = this.settings.mountPoints.filter(m => m.enabled);
+		const mountPaths = new Set(activeMounts.map(m => normalizePath(m.virtualPath)));
+		// Map: path -> MountPoint for tooltip and type-specific styling
+		const mountMap = new Map<string, MountPoint>();
+		for (const m of activeMounts) {
+			mountMap.set(normalizePath(m.virtualPath), m);
+		}
+
+		const mountTypeLabel: Record<string, string> = {
+			local: 'Local folder',
+			vault: 'External vault',
+			webdav: 'WebDAV',
+			s3: 'S3',
+			sftp: 'SFTP',
+		};
+
+		// Process folder items
+		explorerEl.querySelectorAll<HTMLElement>('.nav-folder-title').forEach(el => {
+			const dataPath = el.getAttribute('data-path');
+			if (!dataPath) return;
+			const normalized = normalizePath(dataPath);
+
+			if (mountPaths.has(normalized)) {
+				// This is the mount root folder
+				el.classList.add('folderbridge-mounted');
+				const mount = mountMap.get(normalized);
+				const mountType = mount?.mountType ?? 'local';
+				el.setAttribute('data-folderbridge-mount-type', mountType);
+
+				if (mount) {
+					const typeLabel = mountTypeLabel[mountType] ?? mountType;
+					this.setExplorerMountMetadata(el, mount, typeLabel);
+				}
+			} else {
+				el.classList.remove('folderbridge-mounted');
+				el.removeAttribute('data-folderbridge-mount-type');
+				this.clearExplorerMountMetadata(el);
+			}
+
+			// Check if this folder is a child of a mounted folder
+			const isChild = [...mountPaths].some(mp => normalized.startsWith(mp + '/'));
+			if (isChild) {
+				el.classList.add('folderbridge-mounted-child');
+			} else {
+				el.classList.remove('folderbridge-mounted-child');
+			}
+		});
+
+		// Also mark files inside mounted folders
+		explorerEl.querySelectorAll<HTMLElement>('.nav-file-title').forEach(el => {
+			const dataPath = el.getAttribute('data-path');
+			if (!dataPath) return;
+			const normalized = normalizePath(dataPath);
+
+			const isInMount = [...mountPaths].some(mp => normalized.startsWith(mp + '/'));
+			if (isInMount) {
+				el.classList.add('folderbridge-mounted-child');
+			} else {
+				el.classList.remove('folderbridge-mounted-child');
+			}
+		});
+	}
 
 	private ignoreCache = new Map<string, { nameStrings: string[], pathStrings: string[], regexes: RegExp[] }>();
 
@@ -1753,6 +2119,9 @@ export default class FolderBridgePlugin extends Plugin {
 
 		// [FEATURE_20260222] Start watching the mount for external changes
 		this.fileWatcher?.startWatching(mount);
+
+		// Refresh file-explorer highlights after mount injection
+		setTimeout(() => this.highlightMountedInExplorer(), 200);
 	}
 
 	/**
@@ -1804,6 +2173,9 @@ export default class FolderBridgePlugin extends Plugin {
 		} catch (e) {
 			logger.debug('Folder Bridge: vault.onChange(folder-removed) unavailable', e);
 		}
+
+		// Refresh file-explorer highlights after mount removal
+		setTimeout(() => this.highlightMountedInExplorer(), 200);
 	}
 
 	// ------------------------------------------------------------------

--- a/main.ts
+++ b/main.ts
@@ -45,6 +45,20 @@ type AppInternal = {
 	openWithDefaultApp?(filePath: string): void;
 };
 
+type FileExplorerFolderItem = {
+	setCollapsed?: (collapsed: boolean) => void;
+	collapsed?: boolean;
+	isCollapsed?: boolean;
+	el?: HTMLElement;
+	selfEl?: HTMLElement;
+	containerEl?: HTMLElement;
+	titleEl?: HTMLElement;
+};
+
+type FileExplorerView = {
+	fileItems?: Record<string, FileExplorerFolderItem>;
+};
+
 type DesktopVaultAdapter = DataAdapter & {
 	getBasePath?(): string;
 };
@@ -106,6 +120,8 @@ export default class FolderBridgePlugin extends Plugin {
 	statusBarItem: HTMLElement | null = null;
 	explorerObserver: MutationObserver | null = null;
 	private explorerTooltipRoots = new WeakSet<HTMLElement>();
+	private explorerExpansionRoots = new WeakSet<HTMLElement>();
+	private explorerExpansionSaveTimer: number | null = null;
 	private nativeTooltipObserver: MutationObserver | null = null;
 	private activeExplorerMountTooltipText: string | null = null;
 
@@ -827,6 +843,11 @@ export default class FolderBridgePlugin extends Plugin {
 	}
 
 	onunload() {
+		if (this.explorerExpansionSaveTimer !== null) {
+			window.clearTimeout(this.explorerExpansionSaveTimer);
+			this.explorerExpansionSaveTimer = null;
+			void this.saveSettings();
+		}
 		// Stop the file-explorer highlighting observer
 		this.teardownExplorerHighlighting();
 		this.teardownNativeTooltipObserver();
@@ -893,6 +914,7 @@ export default class FolderBridgePlugin extends Plugin {
 			if (!leaves.length) return;
 			const explorerEl = leaves[0].view.containerEl;
 			this.registerExplorerTooltipAugmentation(explorerEl);
+			this.registerExplorerExpansionTracking(explorerEl);
 			this.setupNativeTooltipObserver();
 
 			if (this.explorerObserver) {
@@ -989,6 +1011,134 @@ export default class FolderBridgePlugin extends Plugin {
 			this.activeExplorerMountTooltipText = null;
 			this.removeMountInfoFromNativeTooltips();
 		}, true);
+	}
+
+	private registerExplorerExpansionTracking(explorerEl: HTMLElement): void {
+		if (this.explorerExpansionRoots.has(explorerEl)) return;
+		this.explorerExpansionRoots.add(explorerEl);
+
+		const scheduleFromEvent = (event: Event) => {
+			const target = event.target;
+			if (!(target instanceof HTMLElement)) return;
+
+			const titleEl = target.closest<HTMLElement>('.nav-folder-title');
+			if (!titleEl || !explorerEl.contains(titleEl)) return;
+
+			const dataPath = titleEl.getAttribute('data-path');
+			if (!dataPath || !this.isFolderBridgeExplorerPath(dataPath)) return;
+
+			this.scheduleExplorerExpansionStateCapture(explorerEl);
+		};
+
+		this.registerDomEvent(explorerEl, 'click', scheduleFromEvent, true);
+		this.registerDomEvent(explorerEl, 'keydown', (event: KeyboardEvent) => {
+			if (!['Enter', ' ', 'ArrowLeft', 'ArrowRight'].includes(event.key)) return;
+			scheduleFromEvent(event);
+		}, true);
+	}
+
+	private getFileExplorerView(): FileExplorerView | null {
+		const leaves = this.app.workspace.getLeavesOfType('file-explorer');
+		if (!leaves.length) return null;
+		return leaves[0].view as unknown as FileExplorerView;
+	}
+
+	private isFolderBridgeExplorerPath(pathValue: string): boolean {
+		const normalized = normalizePath(pathValue);
+		if (!normalized) return false;
+
+		const activeMountPaths = this.settings.mountPoints
+			.filter(m => m.enabled && (m.deviceId === this.settings.deviceId || this.settings.allowForeignMounts))
+			.map(m => normalizePath(m.virtualPath));
+
+		return activeMountPaths.some(mountPath =>
+			normalized === mountPath ||
+			normalized.startsWith(mountPath + '/') ||
+			mountPath.startsWith(normalized + '/')
+		);
+	}
+
+	private scheduleExplorerExpansionStateCapture(explorerEl: HTMLElement): void {
+		window.setTimeout(() => this.captureExplorerExpansionState(explorerEl), 75);
+		window.setTimeout(() => this.captureExplorerExpansionState(explorerEl), 250);
+	}
+
+	private captureExplorerExpansionState(explorerEl: HTMLElement): void {
+		let changed = false;
+		const nextState = {
+			...(this.settings.explorerExpansionState ?? {}),
+		};
+
+		explorerEl.querySelectorAll<HTMLElement>('.nav-folder-title[data-path]').forEach(titleEl => {
+			const dataPath = titleEl.getAttribute('data-path');
+			if (!dataPath || !this.isFolderBridgeExplorerPath(dataPath)) return;
+
+			const normalized = normalizePath(dataPath);
+			const expanded = this.readExplorerFolderExpanded(normalized, titleEl);
+			if (expanded === null) return;
+
+			if (nextState[normalized] !== expanded) {
+				nextState[normalized] = expanded;
+				changed = true;
+			}
+		});
+
+		if (!changed) return;
+		this.settings.explorerExpansionState = nextState;
+		this.queueExplorerExpansionStateSave();
+	}
+
+	private queueExplorerExpansionStateSave(): void {
+		if (this.explorerExpansionSaveTimer !== null) {
+			window.clearTimeout(this.explorerExpansionSaveTimer);
+		}
+		this.explorerExpansionSaveTimer = window.setTimeout(() => {
+			this.explorerExpansionSaveTimer = null;
+			void this.saveSettings();
+		}, 500);
+	}
+
+	private readExplorerFolderExpanded(pathValue: string, titleEl?: HTMLElement): boolean | null {
+		const item = this.getFileExplorerView()?.fileItems?.[normalizePath(pathValue)];
+		if (typeof item?.collapsed === 'boolean') return !item.collapsed;
+		if (typeof item?.isCollapsed === 'boolean') return !item.isCollapsed;
+
+		const itemRoot = item?.selfEl ?? item?.containerEl ?? item?.el ?? item?.titleEl;
+		const folderEl = titleEl?.closest<HTMLElement>('.nav-folder') ?? itemRoot?.closest<HTMLElement>('.nav-folder');
+		if (!folderEl) return null;
+
+		if (folderEl.classList.contains('is-collapsed')) return false;
+		if (folderEl.classList.contains('is-expanded')) return true;
+
+		const childContainer = folderEl.querySelector<HTMLElement>(':scope > .nav-folder-children');
+		if (!childContainer) return null;
+		return window.getComputedStyle(childContainer).display !== 'none';
+	}
+
+	private applySavedExplorerExpansionState(mount: MountPoint): void {
+		const savedState = this.settings.explorerExpansionState ?? {};
+		const savedPaths = Object.keys(savedState);
+		if (savedPaths.length === 0) return;
+
+		const mountPath = normalizePath(mount.virtualPath);
+		const fileItems = this.getFileExplorerView()?.fileItems;
+		if (!fileItems) return;
+
+		for (const savedPath of savedPaths) {
+			const normalized = normalizePath(savedPath);
+			if (
+				normalized !== mountPath &&
+				!normalized.startsWith(mountPath + '/') &&
+				!mountPath.startsWith(normalized + '/')
+			) {
+				continue;
+			}
+
+			const folderItem = fileItems[normalized];
+			if (typeof folderItem?.setCollapsed === 'function') {
+				folderItem.setCollapsed(!savedState[savedPath]);
+			}
+		}
 	}
 
 	private scheduleNativeTooltipAugmentation(folderTitleEl: HTMLElement): void {
@@ -2121,22 +2271,11 @@ export default class FolderBridgePlugin extends Plugin {
 			}
 		}
 
-		// Force the file explorer to refresh the folder contents by expanding and collapsing it
+		// Restore Folder Bridge's own expansion cache after virtual folders have
+		// been injected. Obsidian restores native folder state before these paths
+		// exist, so mount folders need this late pass.
 		if (!suppressionEnabled) setTimeout(() => {
-			const fileExplorerLeaves = this.app.workspace.getLeavesOfType('file-explorer');
-			if (fileExplorerLeaves.length === 0) return;
-
-			type FileExplorerView = { fileItems?: Record<string, { setCollapsed?: (collapsed: boolean) => void }> };
-			const fileExplorerView = fileExplorerLeaves[0].view as unknown as FileExplorerView;
-			const fileItems = fileExplorerView.fileItems;
-
-			const folderPath = normalizePath(mount.virtualPath);
-			if (fileItems && fileItems[folderPath]) {
-				const folderItem = fileItems[folderPath];
-				if (typeof folderItem.setCollapsed === 'function') {
-					folderItem.setCollapsed(false);
-				}
-			}
+			this.applySavedExplorerExpansionState(mount);
 		}, 100);
 
 		// [FEATURE_20260222] Start watching the mount for external changes
@@ -2419,6 +2558,9 @@ export default class FolderBridgePlugin extends Plugin {
 		const data = await this.loadData() as Record<string, unknown>;
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, data);
 		this.settings.managedTocSource = this.settings.managedTocSource ?? '';
+		this.settings.explorerExpansionState = {
+			...(this.settings.explorerExpansionState ?? {}),
+		};
 		this.persistedMountPoints = [...this.settings.mountPoints];
 		this.persistedAllowlist = [...this.settings.allowlist];
 

--- a/main.ts
+++ b/main.ts
@@ -672,8 +672,30 @@ export default class FolderBridgePlugin extends Plugin {
 		// Add context menu item to ignore files/folders
 		this.registerEvent(
 			this.app.workspace.on('file-menu', (menu, file) => {
-				// Only show if the file is inside a mounted folder
 				const mount = this.pathMapper.getMountForPath(file.path);
+
+				if (file instanceof TFolder && !mount) {
+					menu.addItem((item) => {
+						item
+							.setTitle('Mount external folder here\u2026')
+							.setIcon('folder-plus')
+							.onClick(() => {
+								new MountManagerModal(
+									this.app,
+									this.manifest.name,
+									this.security,
+									async (newMount) => { await this.addMount(newMount); },
+									undefined,
+									{
+										mountType: 'local',
+										virtualPath: normalizePath(file.path),
+									},
+								).open();
+							});
+					});
+				}
+
+				// The remaining context actions apply only inside mounted folders.
 				if (!mount) return;
 
 				// "Move mount to…" — only on the mount's own root folder

--- a/src/FileWatcher.ts
+++ b/src/FileWatcher.ts
@@ -171,6 +171,10 @@ export class FileWatcher {
             // Per-mount polling override (useful for network drives / NAS that don't
             // support native inotify / kqueue / ReadDirectoryChangesW events)
             usePolling: mount.watcherUsePolling ?? false,
+            // Obsidian's Electron runtime can expose an incompatible fsevents
+            // binding on macOS. Force chokidar onto fs.watch/polling so watcher
+            // startup cannot crash with native fsevents argument errors.
+            useFsEvents: false,
             interval: mount.watcherPollingIntervalMs ?? 2000,
             awaitWriteFinish: {
                 stabilityThreshold: 500,

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,6 +128,12 @@ export interface FolderBridgeSettings {
 	globalIgnorePatterns: string[];
 	/** Set to true after the first-run welcome modal has been shown. */
 	hasSeenOnboarding: boolean;
+	/**
+	 * File explorer expansion state for virtual mount folders and their
+	 * descendants. Obsidian restores native folders before Folder Bridge injects
+	 * virtual folders, so these paths need a plugin-owned state cache.
+	 */
+	explorerExpansionState: Record<string, boolean>;
 }
 
 export const DEFAULT_SETTINGS: FolderBridgeSettings = {
@@ -143,6 +149,7 @@ export const DEFAULT_SETTINGS: FolderBridgeSettings = {
 	maxDataUriMB: 10,
 	globalIgnorePatterns: ['.DS_Store', 'Thumbs.db', 'desktop.ini', '.git'],
 	hasSeenOnboarding: false,
+	explorerExpansionState: {},
 };
 
 export interface MountStatus {

--- a/src/ui/MountManagerModal.ts
+++ b/src/ui/MountManagerModal.ts
@@ -157,6 +157,7 @@ export class VaultFolderPickerModal extends SuggestModal<string> {
 
 /** Callback invoked by the modal when the user successfully validates a mount. */
 export type OnMountSave = (mount: Omit<MountPoint, 'id'>, editId?: string) => Promise<void>;
+type MountManagerInitialValues = Partial<Pick<MountPoint, 'mountType' | 'virtualPath' | 'realPath' | 'label' | 'readOnly'>>;
 
 // ---------------------------------------------------------------------------
 // MountManagerModal
@@ -222,7 +223,14 @@ export class MountManagerModal extends Modal {
 	private cancelButton: ButtonComponent | null = null;
 	private readonly submitState: SubmitStateController;
 
-	constructor(app: App, pluginName: string, security: SecurityManager, onSave: OnMountSave, editMount?: MountPoint) {
+	constructor(
+		app: App,
+		pluginName: string,
+		security: SecurityManager,
+		onSave: OnMountSave,
+		editMount?: MountPoint,
+		initialValues?: MountManagerInitialValues,
+	) {
 		super(app);
 		this.pluginName = pluginName;
 		this.security = security;
@@ -264,6 +272,12 @@ export class MountManagerModal extends Modal {
 			this.watcherCreateFilter = editMount.watcherCreateFilter ?? 'all';
 			this.watcherSuppressAllEvents = editMount.watcherSuppressAllEvents ?? false;
 			this.maxFiles = editMount.maxFiles;
+		} else if (initialValues) {
+			this.mountType = initialValues.mountType ?? this.mountType;
+			this.virtualPath = initialValues.virtualPath ?? this.virtualPath;
+			this.realPath = initialValues.realPath ?? this.realPath;
+			this.readOnly = initialValues.readOnly ?? this.readOnly;
+			this.label = initialValues.label ?? this.label;
 		}
 	}
 

--- a/styles.css
+++ b/styles.css
@@ -251,3 +251,95 @@
     gap: 10px;
     margin-top: 20px;
 }
+
+/* ── File explorer mounted-folder indicators ─────────────────────────────── */
+
+/* Make the inner label fill the row so ::after can push to the right */
+.nav-folder-title.folderbridge-mounted .tree-item-inner {
+    display: flex;
+    align-items: center;
+    flex: 1;
+}
+
+/* Mount root folder: subtle link icon pushed to the right edge */
+.nav-folder-title.folderbridge-mounted .tree-item-inner::after {
+    margin-left: auto;
+    padding-left: 8px;
+    font-size: 0.75em;
+    opacity: 0.5;
+    font-weight: 400;
+}
+
+/* Mount-type-specific indicator colors */
+.nav-folder-title.folderbridge-mounted[data-folderbridge-mount-type="webdav"] .tree-item-inner::after {
+    content: "☁";
+    opacity: 0.55;
+    color: var(--color-blue);
+}
+
+.nav-folder-title.folderbridge-mounted[data-folderbridge-mount-type="s3"] .tree-item-inner::after {
+    content: "☁";
+    opacity: 0.55;
+    color: var(--color-orange);
+}
+
+.nav-folder-title.folderbridge-mounted[data-folderbridge-mount-type="sftp"] .tree-item-inner::after {
+    content: "⇄";
+    opacity: 0.55;
+    color: var(--color-green);
+}
+
+.nav-folder-title.folderbridge-mounted[data-folderbridge-mount-type="local"] .tree-item-inner::after {
+    content: "↗";
+    opacity: 0.5;
+    color: var(--text-muted);
+}
+
+/* Default (vault mount or unknown): also show the link icon */
+.nav-folder-title.folderbridge-mounted:not([data-folderbridge-mount-type]) .tree-item-inner::after,
+.nav-folder-title.folderbridge-mounted[data-folderbridge-mount-type="vault"] .tree-item-inner::after {
+    content: "↗";
+    opacity: 0.5;
+    color: var(--text-muted);
+}
+
+/* Hover: make the indicator more visible */
+.nav-folder-title.folderbridge-mounted:hover .tree-item-inner::after {
+    opacity: 0.8;
+}
+
+.tooltip.folderbridge-tooltip-container-augmented {
+    width: max-content !important;
+    max-width: min(70vw, 720px) !important;
+    height: auto !important;
+    min-height: unset !important;
+    max-height: none !important;
+    padding: 4px 8px !important;
+    border-radius: 4px;
+    overflow: visible !important;
+}
+
+.tooltip .folderbridge-tooltip-augmented {
+    display: block;
+    text-align: left;
+    white-space: nowrap;
+    width: max-content !important;
+    max-width: min(70vw, 720px) !important;
+    height: auto !important;
+    min-height: unset !important;
+    max-height: none !important;
+    overflow: visible !important;
+    opacity: 0.9;
+}
+
+.tooltip .folderbridge-tooltip-augmented .folderbridge-tooltip-line {
+    display: block;
+    max-width: min(70vw, 720px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 1.35;
+}
+
+.tooltip .folderbridge-tooltip-augmented .folderbridge-tooltip-line:not(:first-child) {
+    font-size: var(--font-ui-smaller);
+}


### PR DESCRIPTION
## Summary
- Add file explorer indicators for mounted folder roots by mount type.
- Merge mount type/path metadata into Obsidian's native file explorer folder tooltip.
- Add a folder context-menu action to mount an external folder at the selected vault folder.
- Disable the fsevents watcher backend in Obsidian's Electron runtime to avoid startup crashes.

## Testing
- npm run validate
- Manual testing in Obsidian: mount-root tooltip, mounted-folder icon, folder context Mount action